### PR TITLE
Footprint reduction 1: shrink struct pci_smbus_controller by reducing the impact of redundancy

### DIFF
--- a/system/smbus.c
+++ b/system/smbus.c
@@ -41,70 +41,125 @@ static void ich5_get_smb(void);
 static uint8_t ich5_process(void);
 static uint8_t ich5_read_spd_byte(uint8_t adr, uint16_t cmd);
 
-static const struct pci_smbus_controller smbcontrollers[] = {
-    {0x8086, 0x2413, "82801AA (ICH)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2423, "82801AB (ICH)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2443, "82801BA (ICH2)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2483, "82801CA (ICH3)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x24C3, "82801DB (ICH4)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x24D3, "82801E (ICH5)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x25A4, "6300ESB",                 ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x266A, "82801F (ICH6)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x269B, "6310ESB/6320ESB",         ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x27DA, "82801G (ICH7)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x283E, "82801H (ICH8)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2930, "82801I (ICH9)",           ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x5032, "EP80579 (Tolapai)",       ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x3A30, "ICH10",                   ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x3A60, "ICH10",                   ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x3B30, "5/3400 Series (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1C22, "6 Series (PCH)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1D22, "Patsburg (PCH)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1D70, "Patsburg (PCH) IDF",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1D71, "Patsburg (PCH) IDF",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1D72, "Patsburg (PCH) IDF",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2330, "DH89xxCC (PCH)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1E22, "Panther Point (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8C22, "Lynx Point (PCH)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x9C22, "Lynx Point-LP (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1F3C, "Avoton (SOC)",            ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8D22, "Wellsburg (PCH)",         ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8D7D, "Wellsburg (PCH) MS",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8D7E, "Wellsburg (PCH) MS",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8D7F, "Wellsburg (PCH) MS",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x23B0, "Coleto Creek (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x8CA2, "Wildcat Point (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x9CA2, "Wildcat Point-LP (PCH)",  ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x0F12, "BayTrail (SOC)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x2292, "Braswell (SOC)",          ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA123, "Sunrise Point-H (PCH) ",  ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x9D23, "Sunrise Point-LP (PCH)",  ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x19DF, "Denverton  (SOC)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x1BC9, "Emmitsburg (PCH)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA1A3, "Lewisburg (PCH)",         ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA223, "Lewisburg Super (PCH)",   ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA2A3, "Kaby Lake (PCH-H)",       ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x31D4, "Gemini Lake (SOC)",       ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA323, "Cannon Lake-H (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x9DA3, "Cannon Lake-LP (PCH)",    ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x18DF, "Cedar Fork (PCH)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x34A3, "Ice Lake-LP (PCH)",       ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x38A3, "Ice Lake-N (PCH)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x02A3, "Comet Lake (PCH)",        ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x06A3, "Comet Lake-H (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x4B23, "Elkhart Lake (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA0A3, "Tiger Lake-LP (PCH)",     ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x43A3, "Tiger Lake-H (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x4DA3, "Jasper Lake (SOC)",       ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0xA3A3, "Comet Lake-V (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x7AA3, "Alder Lake-S (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x51A3, "Alder Lake-P (PCH)",      ich5_get_smb, ich5_read_spd_byte},
-    {0x8086, 0x54A3, "Alder Lake-M (PCH)",      ich5_get_smb, ich5_read_spd_byte},
+#define SMBC_OPS_IDX_ICH5    (1)
+#define SMBC_OPS_IDX_FCH_ZEN (2)
 
-     // AMD SMBUS
-     {0x1022, 0x780B, "AMD FCH", NULL, NULL},
-     {0x1022, 0x790B, "AMD FCH (Zen)",          fch_zen_get_smb, ich5_read_spd_byte},
-     {0, 0, "", NULL, NULL}
+static const struct pci_smbus_controller_ops smbcontrollerops[] = {
+    { NULL, NULL },
+    { ich5_get_smb,    ich5_read_spd_byte },
+    { fch_zen_get_smb, ich5_read_spd_byte }
+};
+
+static const struct pci_smbus_controller smbcontrollers[] = {
+    // Intel SMBus
+    {0x8086, 0x2413,    SMBC_OPS_IDX_ICH5, "82801AA (ICH)"           },
+    {0x8086, 0x2423,    SMBC_OPS_IDX_ICH5, "82801AB (ICH)"           },
+    {0x8086, 0x2443,    SMBC_OPS_IDX_ICH5, "82801BA (ICH2)"          },
+    {0x8086, 0x2483,    SMBC_OPS_IDX_ICH5, "82801CA (ICH3)"          },
+    {0x8086, 0x24C3,    SMBC_OPS_IDX_ICH5, "82801DB (ICH4)"          },
+    {0x8086, 0x24D3,    SMBC_OPS_IDX_ICH5, "82801E (ICH5)"           },
+    {0x8086, 0x25A4,    SMBC_OPS_IDX_ICH5, "6300ESB"                 },
+    {0x8086, 0x266A,    SMBC_OPS_IDX_ICH5, "82801F (ICH6)"           },
+    {0x8086, 0x269B,    SMBC_OPS_IDX_ICH5, "6310ESB/6320ESB"         },
+    {0x8086, 0x27DA,    SMBC_OPS_IDX_ICH5, "82801G (ICH7)"           },
+    {0x8086, 0x283E,    SMBC_OPS_IDX_ICH5, "82801H (ICH8)"           },
+    {0x8086, 0x2930,    SMBC_OPS_IDX_ICH5, "82801I (ICH9)"           },
+    {0x8086, 0x5032,    SMBC_OPS_IDX_ICH5, "EP80579 (Tolapai)"       },
+    {0x8086, 0x3A30,    SMBC_OPS_IDX_ICH5, "ICH10"                   },
+    {0x8086, 0x3A60,    SMBC_OPS_IDX_ICH5, "ICH10"                   },
+    {0x8086, 0x3B30,    SMBC_OPS_IDX_ICH5, "5/3400 Series (PCH)"     },
+    {0x8086, 0x1C22,    SMBC_OPS_IDX_ICH5, "6 Series (PCH)"          },
+    {0x8086, 0x1D22,    SMBC_OPS_IDX_ICH5, "Patsburg (PCH)"          },
+    {0x8086, 0x1D70,    SMBC_OPS_IDX_ICH5, "Patsburg (PCH) IDF"      },
+    {0x8086, 0x1D71,    SMBC_OPS_IDX_ICH5, "Patsburg (PCH) IDF"      },
+    {0x8086, 0x1D72,    SMBC_OPS_IDX_ICH5, "Patsburg (PCH) IDF"      },
+    {0x8086, 0x2330,    SMBC_OPS_IDX_ICH5, "DH89xxCC (PCH)"          },
+    {0x8086, 0x1E22,    SMBC_OPS_IDX_ICH5, "Panther Point (PCH)"     },
+    {0x8086, 0x8C22,    SMBC_OPS_IDX_ICH5, "Lynx Point (PCH)"        },
+    {0x8086, 0x9C22,    SMBC_OPS_IDX_ICH5, "Lynx Point-LP (PCH)"     },
+    {0x8086, 0x1F3C,    SMBC_OPS_IDX_ICH5, "Avoton (SOC)"            },
+    {0x8086, 0x8D22,    SMBC_OPS_IDX_ICH5, "Wellsburg (PCH)"         },
+    {0x8086, 0x8D7D,    SMBC_OPS_IDX_ICH5, "Wellsburg (PCH) MS"      },
+    {0x8086, 0x8D7E,    SMBC_OPS_IDX_ICH5, "Wellsburg (PCH) MS"      },
+    {0x8086, 0x8D7F,    SMBC_OPS_IDX_ICH5, "Wellsburg (PCH) MS"      },
+    {0x8086, 0x23B0,    SMBC_OPS_IDX_ICH5, "Coleto Creek (PCH)"      },
+    {0x8086, 0x8CA2,    SMBC_OPS_IDX_ICH5, "Wildcat Point (PCH)"     },
+    {0x8086, 0x9CA2,    SMBC_OPS_IDX_ICH5, "Wildcat Point-LP (PCH)"  },
+    {0x8086, 0x0F12,    SMBC_OPS_IDX_ICH5, "BayTrail (SOC)"          },
+    {0x8086, 0x2292,    SMBC_OPS_IDX_ICH5, "Braswell (SOC)"          },
+    {0x8086, 0xA123,    SMBC_OPS_IDX_ICH5, "Sunrise Point-H (PCH) "  },
+    {0x8086, 0x9D23,    SMBC_OPS_IDX_ICH5, "Sunrise Point-LP (PCH)"  },
+    {0x8086, 0x19DF,    SMBC_OPS_IDX_ICH5, "Denverton  (SOC)"        },
+    {0x8086, 0x1BC9,    SMBC_OPS_IDX_ICH5, "Emmitsburg (PCH)"        },
+    {0x8086, 0xA1A3,    SMBC_OPS_IDX_ICH5, "Lewisburg (PCH)"         },
+    {0x8086, 0xA223,    SMBC_OPS_IDX_ICH5, "Lewisburg Super (PCH)"   },
+    {0x8086, 0xA2A3,    SMBC_OPS_IDX_ICH5, "Kaby Lake (PCH-H)"       },
+    {0x8086, 0x31D4,    SMBC_OPS_IDX_ICH5, "Gemini Lake (SOC)"       },
+    {0x8086, 0xA323,    SMBC_OPS_IDX_ICH5, "Cannon Lake-H (PCH)"     },
+    {0x8086, 0x9DA3,    SMBC_OPS_IDX_ICH5, "Cannon Lake-LP (PCH)"    },
+    {0x8086, 0x18DF,    SMBC_OPS_IDX_ICH5, "Cedar Fork (PCH)"        },
+    {0x8086, 0x34A3,    SMBC_OPS_IDX_ICH5, "Ice Lake-LP (PCH)"       },
+    {0x8086, 0x38A3,    SMBC_OPS_IDX_ICH5, "Ice Lake-N (PCH)"        },
+    {0x8086, 0x02A3,    SMBC_OPS_IDX_ICH5, "Comet Lake (PCH)"        },
+    {0x8086, 0x06A3,    SMBC_OPS_IDX_ICH5, "Comet Lake-H (PCH)"      },
+    {0x8086, 0x4B23,    SMBC_OPS_IDX_ICH5, "Elkhart Lake (PCH)"      },
+    {0x8086, 0xA0A3,    SMBC_OPS_IDX_ICH5, "Tiger Lake-LP (PCH)"     },
+    {0x8086, 0x43A3,    SMBC_OPS_IDX_ICH5, "Tiger Lake-H (PCH)"      },
+    {0x8086, 0x4DA3,    SMBC_OPS_IDX_ICH5, "Jasper Lake (SOC)"       },
+    {0x8086, 0xA3A3,    SMBC_OPS_IDX_ICH5, "Comet Lake-V (PCH)"      },
+    {0x8086, 0x7AA3,    SMBC_OPS_IDX_ICH5, "Alder Lake-S (PCH)"      },
+    {0x8086, 0x51A3,    SMBC_OPS_IDX_ICH5, "Alder Lake-P (PCH)"      },
+    {0x8086, 0x54A3,    SMBC_OPS_IDX_ICH5, "Alder Lake-M (PCH)"      },
+
+    // AMD SMBus
+//  {0x1022, 0x780B,                    0, ""                        },
+    {0x1022, 0x790B, SMBC_OPS_IDX_FCH_ZEN, "AMD FCH (Zen)",          },
+//  {0x1D94, 0x790B,                       "Chengdu Haiguang IC Design Co., Ltd. (Hygon) FCH SMBus Controller" },
+
+    // NOTE: Linux PCI IDs list / web site and Linux source code (drivers/i2c/busses/i2c*.c)
+    // contain other SMBus controller models from AMD, SiS, Nvidia, Intel not supported by this code.
+    // Most of these are only present in old hardware, though.
+
+    // AMD SMBus
+//  {0x1002, 0x4353,                       "SB200"                   },
+//  {0x1002, 0x4363,                       "SB300"                   },
+//  {0x1002, 0x4372,                       "IXP SB4x0"               },
+//  {0x1002, 0x4385,                       "SB600/700",              }, // PIIX4
+//  {0x1022, 0x13E7,                       "Ariel"                   },
+//  {0x1022, 0x746A,                       "AMD-8111 SMBus 2.0"      },
+
+    // SiS SMBus
+//  {0x1039, 0x0016,                       "SiS961/2/3"              },
+
+    // Nvidia SMBus
+//  {0x10DE, 0x0034,                       "MCP04"                   },
+//  {0x10DE, 0x0052,                       "CK804"                   },
+//  {0x10DE, 0x0064,                       "nForce2 (MCP)"           },
+//  {0x10DE, 0x0084,                       "MCP2A"                   },
+//  {0x10DE, 0x00D4,                       "nForce3"                 },
+//  {0x10DE, 0x0264,                       "MCP51"                   },
+//  {0x10DE, 0x0368,                       "MCP55"                   },
+//  {0x10DE, 0x03EB,                       "MCP61"                   },
+//  {0x10DE, 0x0446,                       "MCP65"                   },
+//  {0x10DE, 0x0542,                       "MCP67"                   },
+//  (0x10DE, 0x0752,                       "MCP78S [GeForce 8200] SMBus - maybe irrelevant)
+//  {0x10DE, 0x07D8,                       "MCP73"                   },
+//  {0x10DE, 0x0AA2,                       "MCP79"                   },
+//  {0x10DE, 0x0D79,                       "MCP89"                   },
+
+    // Intel SMBus
+//  {0x8086, 0x0C59,                       "Atom Processor S1200 SMBus 2.0 Controller 0 - ?" },
+//  {0x8086, 0x0C5A,                       "Atom Processor S1200 SMBus 2.0 Controller 1 - ?" },
+//  {0x8086, 0x0C5B,                       "Atom Processor S1200 SMBus Controller 2 - ?" },
+//  {0x8086, 0x0C5C,                       "Atom Processor S1200 SMBus Controller 3 - ?" },
+//  {0x8086, 0x0C5D,                       "Atom Processor S1200 SMBus Controller 4 - ?" },
+//  {0x8086, 0x0C5E,                       "Atom Processor S1200 SMBus Controller 5 - ?" },
+//  (0x8086, 0x0F13,                       "ValleyView SMBus Controller - unconfirmed)
+//  {0x8086, 0x19AC,                       "Atom Processor C3000 Series SMBus Contoller - Host - ?" },
+//  {0x8086, 0x1F15,                       "Atom processor C2000 SMBus 2.0 - ?" },
+//  (0x8086, 0x1F3D,                       "Atom Processor C2000 PECI SMBus - maybe irrelevant)
+//  {0x8086, 0x7603,                       "82372FB PIIX5"           },
+//  {0x8086, 0x8119,                       "US15W"                   }, // US15W
 };
 
 void print_smbus_startup_info(void) {
@@ -122,7 +177,7 @@ void print_smbus_startup_info(void) {
         return;
     }
 
-    smbcontrollers[index].get_adr();
+    smbcontrollerops[smbcontrollers[index].ops].get_adr();
 
     for (spdidx = 0; spdidx < MAX_SPD_SLOT; spdidx++) {
 

--- a/system/smbus.h
+++ b/system/smbus.h
@@ -51,12 +51,16 @@
 
 #define SPD5_MR11 11
 
-struct pci_smbus_controller{
-    unsigned vendor;
-    unsigned device;
-    char *name;
+struct pci_smbus_controller_ops {
     void (*get_adr)(void);
     uint8_t (*read_spd_byte)(uint8_t dimmadr, uint16_t bytenum);
+};
+
+struct pci_smbus_controller {
+    uint16_t vendor;
+    uint16_t device;
+    uint16_t ops;
+    char     *name;
 };
 
 typedef struct spd_infos {
@@ -91,7 +95,7 @@ typedef struct ram_infos {
 extern ram_info ram;
 
 #define get_spd(smb_idx, slot_idx, spd_adr) \
-    smbcontrollers[smb_idx].read_spd_byte(slot_idx, spd_adr)
+    smbcontrollerops[smbcontrollers[smb_idx].ops].read_spd_byte(slot_idx, spd_adr)
 
 /**
  * Print SMBUS Info


### PR DESCRIPTION
The pointers from pci_smbus_controller are highly redundant, so push them aside to a single struct.
I tested this on real hardware before the latest rebase.