### PR TITLE
SMBIOS parser fixes and fuzzing code

### DIFF
--- a/system/smbios.h
+++ b/system/smbios.h
@@ -31,7 +31,7 @@ typedef struct {
     uint32_t tableaddress;
     uint16_t numstructs;
     uint8_t SMBIOSrev;
-} smbios_t;
+} smbiosv2_t;
 
 struct tstruct_header {
     uint8_t type;
@@ -41,38 +41,53 @@ struct tstruct_header {
 
 struct system_map {
     struct tstruct_header header;
-    uint8_t manufacturer;
-    uint8_t productname;
-    uint8_t version;
-    uint8_t serialnumber;
-    uint8_t uuidbytes[16];
-    uint8_t wut;
+    uint8_t  manufacturer;
+    uint8_t  productname;
+    uint8_t  version;
+    uint8_t  serialnumber; // Last field defined by SMBIOS 2.3.
+    uint8_t  asset_tag;
+    uint8_t  feature_flags;
+    uint8_t  location_in_chassis;
+    uint16_t chassis_handle;
+    uint8_t  board_type;
+    uint16_t number_contained_object_handles;
+} __attribute__((packed));
+
+struct mem_module {
+    struct tstruct_header header;
+    uint8_t  socket_designation;
+    uint8_t  bank_connections;
+    uint8_t  current_speed;
+    uint16_t current_memory_type;
+    uint8_t  installed_size;
+    uint8_t  enabled_size;
+    uint8_t  error_status;
 } __attribute__((packed));
 
 struct mem_dev {
-	struct tstruct_header header;
-	uint16_t pma_handle;
-	uint16_t err_handle;
-	uint16_t tot_width;
-	uint16_t dat_width;
-	uint16_t size;
-	uint8_t  form;
-	uint8_t  set;
-	uint8_t  dev_locator;
-	uint8_t  bank_locator;
-	uint8_t  type;
-	uint16_t typedetail;
-	uint16_t speed;
-	uint8_t  manufacturer;
-	uint8_t  serialnum;
-	uint8_t  asset;
-	uint8_t  partnum;
-	uint8_t  attributes;
-	uint8_t  ext_size;
-	uint8_t  conf_ram_speed;
-	uint8_t  min_voltage;
-	uint8_t  max_votage;
-	uint8_t  conf_voltage;
+    struct tstruct_header header;
+    uint16_t pma_handle;
+    uint16_t err_handle;
+    uint16_t tot_width;
+    uint16_t dat_width;
+    uint16_t size;
+    uint8_t  form;
+    uint8_t  set;
+    uint8_t  dev_locator;
+    uint8_t  bank_locator;
+    uint8_t  type;
+    uint16_t typedetail;
+    uint16_t speed;
+    uint8_t  manufacturer;
+    uint8_t  serialnum;
+    uint8_t  asset;
+    uint8_t  partnum; // Last field defined by SMBIOS 2.3.
+    uint8_t  attributes;
+    uint8_t  ext_size;
+    uint8_t  conf_ram_speed;
+    uint8_t  min_voltage;
+    uint8_t  max_votage;
+    uint8_t  conf_voltage;
 } __attribute__((packed));
 
 /**


### PR DESCRIPTION
I've fixed the OOB accesses and tested the fixed code on a real computer (ASUS P5QC): the manufacturer and product name are displayed both with and without the changes in this PR. There's also a sprinkling of whitespace changes.

In the PR version of the changes, I used the `tests` directory to store the build script, since it's a common name for unit tests; this code base uses this directory for other purposes, though :)