### PR TITLE
Small optimizations in the EHCI code

### DIFF
--- a/system/ehci.c
+++ b/system/ehci.c
@@ -246,17 +246,17 @@ static int usb_to_ehci_speed(usb_speed_t usb_speed)
     }
 }
 
-int num_ehci_ports(uint32_t hcs_params)
+static int num_ehci_ports(uint32_t hcs_params)
 {
     return (hcs_params >> 0) & 0xf;
 }
 
-int num_ehci_companions(uint32_t hcs_params)
+static int num_ehci_companions(uint32_t hcs_params)
 {
     return (hcs_params >> 12) & 0xf;
 }
 
-int ehci_ext_cap_ptr(uint32_t hcc_params)
+static int ehci_ext_cap_ptr(uint32_t hcc_params)
 {
     return (hcc_params >> 8) & 0xff;
 }
@@ -407,7 +407,7 @@ static bool reset_root_hub_port(const usb_hcd_t *hcd, int port_num)
     return reset_ehci_port(ws->op_regs, port_num - 1);
 }
 
-bool assign_address(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num,
+static bool assign_address(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num,
                     usb_speed_t device_speed, int device_id, usb_ep_t *ep0)
 {
     // Store the extra information needed by build_ehci_qhd().

--- a/system/uhci.c
+++ b/system/uhci.c
@@ -54,7 +54,7 @@
 #define UHCI_USBSTS_HCPE        0x0010              // Host Controller Processor Error
 #define UHCI_USBSTS_HCH         0x0020              // Host Controller Halted
 
-// Port Status and Control register 
+// Port Status and Control register
 
 #define UHCI_PORT_SC_CCS        0x0001              // Current Connect Status
 #define UHCI_PORT_SC_CCSC       0x0002              // Current Connect Status Change
@@ -66,7 +66,7 @@
 #define UHCI_PORT_SC_PR         0x0200              // Port Reset
 #define UHCI_PORT_SC_SUSPEND    0x1000              // Suspend
 
-// Link Pointer 
+// Link Pointer
 
 #define UHCI_LP_TERMINATE       0x00000001          // Terminate (T) bit
 
@@ -261,7 +261,7 @@ static void build_uhci_td(uhci_td_t *td, const usb_ep_t *ep, uint32_t pid, uint3
 static uint16_t get_uhci_done(workspace_t *ws)
 {
     uint16_t io_base = ws->io_base;
-    
+
     uint16_t status = inw(UHCI_USBSTS) & (UHCI_USBSTS_INT | UHCI_USBSTS_ERR);
     if (status != 0) {
         outw(UHCI_USBSTS_INT | UHCI_USBSTS_ERR, UHCI_USBSTS);

--- a/system/xhci.c
+++ b/system/xhci.c
@@ -881,7 +881,6 @@ static int identify_keyboard(workspace_t *ws, int slot_id, int ep_id)
     return -1;
 }
 
-
 static uint8_t get_keycode(const usb_hcd_t *hcd)
 {
     workspace_t *ws = (workspace_t *)hcd->ws;


### PR DESCRIPTION
I noticed these missing `static` keywords by chance when scrolling down into `system/ehci.c` to reach the location I needed to modify for a test related to #6 . Then, I browsed through the other `*hci.c` files, and fixed several whitespace errors as a result.