### PR TITLE
Add support for disabling the CPU cache

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -93,6 +93,7 @@ cpu_state_t     cpu_state[MAX_CPUS];
 
 bool            enable_temperature = false;
 bool            enable_trace       = false;
+bool            enable_cpucache    = true;
 
 bool            enable_sm          = true;
 bool            enable_bench       = true;
@@ -185,6 +186,8 @@ static void parse_option(const char *option, const char *params)
         }
     } else if (strncmp(option, "nobench", 8) == 0) {
         enable_bench = false;
+    } else if (strncmp(option, "nocpucache", 11) == 0) {
+        enable_cpucache = false;
     } else if (strncmp(option, "noehci", 7) == 0) {
         usb_init_options |= USB_IGNORE_EHCI;
     } else if (strncmp(option, "nopause", 8) == 0) {

--- a/app/config.c
+++ b/app/config.c
@@ -91,7 +91,7 @@ bool            smp_enabled        = true;
 
 bool            enable_temperature = true;
 bool            enable_trace       = false;
-bool            enable_cpucache    = true;
+bool            enable_cpu_cache   = true;
 
 bool            enable_sm          = true;
 bool            enable_bench       = true;
@@ -185,7 +185,7 @@ static void parse_option(const char *option, const char *params)
     } else if (strncmp(option, "nobench", 8) == 0) {
         enable_bench = false;
     } else if (strncmp(option, "nocpucache", 11) == 0) {
-        enable_cpucache = false;
+        enable_cpu_cache = false;
     } else if (strncmp(option, "noehci", 7) == 0) {
         usb_init_options |= USB_IGNORE_EHCI;
     } else if (strncmp(option, "nopause", 8) == 0) {

--- a/app/config.h
+++ b/app/config.h
@@ -49,7 +49,7 @@ extern bool         smp_enabled;
 
 extern bool         enable_temperature;
 extern bool         enable_trace;
-extern bool         enable_cpucache;
+extern bool         enable_cpu_cache;
 
 extern bool         enable_sm;
 extern bool         enable_tty;

--- a/app/config.h
+++ b/app/config.h
@@ -47,6 +47,7 @@ extern cpu_state_t  cpu_state[MAX_CPUS];
 
 extern bool         enable_temperature;
 extern bool         enable_trace;
+extern bool         enable_cpucache;
 
 extern bool         enable_sm;
 extern bool         enable_tty;

--- a/app/display.c
+++ b/app/display.c
@@ -144,8 +144,9 @@ void display_init(void)
         display_cpu_addr_mode("[PAE]");
     }
 #endif
-    display_cpu_cache_mode();
-    if (l1_cache) {
+    if (!enable_cpu_cache) {
+        display_cpu_cache_mode();
+    } else if (l1_cache) {
         display_l1_cache_size(l1_cache);
     }
     if (l2_cache) {

--- a/app/display.c
+++ b/app/display.c
@@ -130,6 +130,7 @@ void display_init(void)
     } else if (cpuid_info.flags.pae) {
         display_cpu_addr_mode("(PAE)");
     }
+    display_cpu_cache_mode();
     if (l1_cache) {
         display_l1_cache_size(l1_cache);
     }

--- a/app/display.h
+++ b/app/display.h
@@ -41,6 +41,11 @@
 #define display_cpu_addr_mode(str) \
     prints(1, 20, str)
 
+#define display_cpu_cache_mode() \
+    if (!enable_cpucache) { \
+        prints(1, 25, " UC"); \
+    }
+
 #define display_l1_cache_size(size) \
     printf(2, 10, "%kB", (uintptr_t)(size))
 

--- a/app/display.h
+++ b/app/display.h
@@ -49,11 +49,7 @@ typedef enum {
     prints(4, 75, str)
 
 #define display_cpu_cache_mode() \
-    { \
-        if (!enable_cpu_cache) {   \
-            prints(1, 25, " UC");  \
-        } \
-    }
+    prints(2, 10, "Disabled")
 
 #define display_l1_cache_size(size) \
     printf(2, 9, "%6kB", (uintptr_t)(size))

--- a/app/display.h
+++ b/app/display.h
@@ -49,8 +49,10 @@ typedef enum {
     prints(4, 75, str)
 
 #define display_cpu_cache_mode() \
-    if (!enable_cpucache) { \
-        prints(1, 25, " UC"); \
+    { \
+        if (!enable_cpu_cache) {   \
+            prints(1, 25, " UC");  \
+        } \
     }
 
 #define display_l1_cache_size(size) \

--- a/app/main.c
+++ b/app/main.c
@@ -469,8 +469,7 @@ void main(void)
     if (init_state < 2) {
         if (enable_cpu_cache) {
             cache_on();
-        }
-        else {
+        } else {
             cache_off();
         }
         if (my_cpu == 0) {

--- a/app/main.c
+++ b/app/main.c
@@ -467,7 +467,7 @@ void main(void)
         my_cpu = smp_my_cpu_num();
     }
     if (init_state < 2) {
-        if (enable_cpucache) {
+        if (enable_cpu_cache) {
             cache_on();
         }
         else {

--- a/app/main.c
+++ b/app/main.c
@@ -466,7 +466,12 @@ void main(void)
         my_cpu = smp_my_cpu_num();
     }
     if (init_state < 2) {
-        cache_on();
+        if (enable_cpucache) {
+            cache_on();
+        }
+        else {
+            cache_off();
+        }
         if (my_cpu == 0) {
             global_init();
             init_state = 1;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -115,7 +115,7 @@ int run_test(int my_cpu, int test, int stage, int iterations)
       case 0:
         if (my_cpu >= 0) cache_off();
         ticks += test_addr_walk1(my_cpu);
-        if (my_cpu >= 0) cache_on();
+        if (my_cpu >= 0 && enable_cpucache) cache_on();
         BAILOUT;
         break;
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -115,7 +115,7 @@ int run_test(int my_cpu, int test, int stage, int iterations)
       case 0:
         if (my_cpu >= 0) cache_off();
         ticks += test_addr_walk1(my_cpu);
-        if (my_cpu >= 0 && enable_cpucache) cache_on();
+        if (my_cpu >= 0 && enable_cpu_cache) cache_on();
         BAILOUT;
         break;
 


### PR DESCRIPTION
It makes the test horrendously slow on recent computers which have lots of RAM.

The original version of this code was made before the cache / memory benchmark was restored, and this seems to run with cache enabled, judging by the displayed speeds; shouldn't I attempt to modify the benchmark, in `measure_memory_bandwidth` and possibly `display_init` ?