### PR TITLE
Add support for parsing DMI struct type 1 as fallback for type 2

### DIFF
--- a/system/smbios.h
+++ b/system/smbios.h
@@ -9,12 +9,19 @@
  * Copyright (C) 2004-2022 Samuel Demeulemeester.
  */
 
-#define DMI_SDR     0x0F
-#define DMI_DDR     0x12
-#define DMI_DDR2    0x13
-#define DMI_DDR3    0x18
-#define DMI_DDR4    0x1A
-#define DMI_DDR5    0x22
+#define DMI_SDR         0x0F
+#define DMI_RDRAM       0x11
+#define DMI_DDR         0x12
+#define DMI_DDR2        0x13
+#define DMI_DDR2_FBDIMM 0x14
+#define DMI_DDR3        0x18
+#define DMI_DDR4        0x1A
+#define DMI_LPDDR       0x1B
+#define DMI_LPDDR2      0x1C
+#define DMI_LPDDR3      0x1D
+#define DMI_LPDDR4      0x1E
+#define DMI_DDR5        0x22
+#define DMI_LPDDR5      0x23
 
 typedef struct {
     uint8_t anchor[4];
@@ -39,18 +46,30 @@ struct tstruct_header {
     uint16_t handle;
 } __attribute__((packed));
 
-struct system_map {
+struct system_info {
+    struct tstruct_header header;
+    uint8_t  manufacturer;
+    uint8_t  productname;
+    uint8_t  version;
+    uint8_t  serialnumber;
+    uint8_t  uuidbytes[16];
+    uint8_t  wut; // Last field defined by SMBIOS 2.3.
+    /*uint8_t  sku_number;
+    uint8_t  family;*/
+} __attribute__((packed));
+
+struct baseboard_info {
     struct tstruct_header header;
     uint8_t  manufacturer;
     uint8_t  productname;
     uint8_t  version;
     uint8_t  serialnumber; // Last field defined by SMBIOS 2.3.
-    uint8_t  asset_tag;
+    /*uint8_t  asset_tag;
     uint8_t  feature_flags;
     uint8_t  location_in_chassis;
     uint16_t chassis_handle;
     uint8_t  board_type;
-    uint16_t number_contained_object_handles;
+    uint16_t number_contained_object_handles;*/
 } __attribute__((packed));
 
 struct mem_module {
@@ -82,12 +101,25 @@ struct mem_dev {
     uint8_t  serialnum;
     uint8_t  asset;
     uint8_t  partnum; // Last field defined by SMBIOS 2.3.
-    uint8_t  attributes;
-    uint8_t  ext_size;
-    uint8_t  conf_ram_speed;
-    uint8_t  min_voltage;
-    uint8_t  max_votage;
-    uint8_t  conf_voltage;
+    /*uint8_t  attributes;
+    uint32_t ext_size;
+    uint16_t conf_ram_speed;
+    uint16_t min_voltage;
+    uint16_t max_votage;
+    uint16_t conf_voltage;
+    uint8_t  technology;
+    uint16_t operating_mode_capability;
+    uint8_t  firmware_version;
+    uint16_t module_manufacturer_id;
+    uint16_t module_product_id;
+    uint16_t mem_subsystem_controller_manufacturer_id;
+    uint16_t mem_subsystem_controller_product_id;
+    uint64_t nonvolatile_size;
+    uint64_t volatile_size;
+    uint64_t cache_size;
+    uint64_t logical_size;
+    uint32_t extended_speed;
+    uint32_t extended_conf_speed;*/
 } __attribute__((packed));
 
 /**


### PR DESCRIPTION
Needed on e.g. HP Proliant DL360 G7, which has a struct type 1 instance but not a struct type 2 instance, as allowed by the SMBIOS standard..