### PR TITLE
Various aesthetic changes, more information displayed (and code for detection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ memtest_shared.bin
 grub-iso
 html
 latex
+
+# hash file
+githash.h

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Object files
 *.o
 
+# Generated file
+githash.h
+
 # Binaries
 memtest_shared
 memtest_shared.bin
@@ -21,5 +24,4 @@ grub-iso
 html
 latex
 
-# hash file
-githash.h
+

--- a/app/config.c
+++ b/app/config.c
@@ -91,7 +91,7 @@ error_mode_t    error_mode = ERROR_MODE_NONE;
 
 cpu_state_t     cpu_state[MAX_CPUS];
 
-bool            enable_temperature = false;
+bool            enable_temperature = true;
 bool            enable_trace       = false;
 
 bool            enable_sm          = true;
@@ -761,7 +761,7 @@ void config_init(void)
         cpu_state[i] = CPU_STATE_ENABLED;
     }
 
-    enable_temperature = !no_temperature;
+    enable_temperature &= !no_temperature;
 
     power_save = POWER_SAVE_HIGH;
 

--- a/app/config.c
+++ b/app/config.c
@@ -66,15 +66,11 @@
 
 #define SEL_AREA    (SEL_W * SEL_H)
 
-static const char *cpu_mode_str[] = { "PAR", "SEQ", "RR " };
-
 //------------------------------------------------------------------------------
 // Private Variables
 //------------------------------------------------------------------------------
 
 static uint16_t popup_save_buffer[POP_W * POP_H];
-
-static bool smp_enabled = true;
 
 //------------------------------------------------------------------------------
 // Public Variables
@@ -91,13 +87,15 @@ error_mode_t    error_mode = ERROR_MODE_NONE;
 
 cpu_state_t     cpu_state[MAX_CPUS];
 
+bool            smp_enabled        = true;
+
 bool            enable_temperature = true;
 bool            enable_trace       = false;
 
 bool            enable_sm          = true;
 bool            enable_bench       = true;
 
-bool            pause_at_start     = false;
+bool            pause_at_start     = true;
 
 power_save_t    power_save         = POWER_SAVE_HIGH;
 
@@ -867,7 +865,7 @@ void config_menu(bool initial)
     }
 
     if (cpu_mode != old_cpu_mode) {
-        display_cpu_mode(cpu_mode_str[cpu_mode]);
+        display_cpu_topology();
         restart = true;
     }
 

--- a/app/config.h
+++ b/app/config.h
@@ -45,6 +45,8 @@ extern error_mode_t error_mode;
 
 extern cpu_state_t  cpu_state[MAX_CPUS];
 
+extern bool         smp_enabled;
+
 extern bool         enable_temperature;
 extern bool         enable_trace;
 

--- a/app/display.c
+++ b/app/display.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "error.h"
+#include "githash.h"
 
 #include "tests.h"
 
@@ -76,13 +77,9 @@ void display_init(void)
     set_foreground_colour(BLACK);
     set_background_colour(WHITE);
     clear_screen_region(0, 0, 0, 27);
-#if TESTWORD_WIDTH > 32
-    prints(0, 0, "  Memtest86+ v6.00pre (64b)");
-#else
-    prints(0, 0, "  Memtest86+ v6.00pre (32b)");
-#endif
+    prints(0, 0, "     Memtest86+ v6.00b1");
     set_foreground_colour(RED);
-    printc(0, 11, '+');
+    printc(0, 14, '+');
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
     prints(0,28,                             "| ");
@@ -118,6 +115,13 @@ void display_init(void)
     set_background_colour(WHITE);
     clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
     prints(ROW_FOOTER, 0, " <ESC> exit  <F1> configuration  <Space> scroll lock");
+    prints(ROW_FOOTER, 64, "6.00.");
+    prints(ROW_FOOTER, 69, GIT_HASH);
+#if TESTWORD_WIDTH > 32
+    prints(ROW_FOOTER, 76, ".x64");
+#else
+    prints(ROW_FOOTER, 76, ".x32");
+#endif
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
 

--- a/app/display.c
+++ b/app/display.c
@@ -66,6 +66,8 @@ static bool timed_update_done = false;  // update cycle status
 
 int scroll_message_row;
 
+int display_mode = 0; // RAM Info from: 0 = N/A - 1 = SPD - 2 = IMC
+
 int max_cpu_temp = 0;
 
 //------------------------------------------------------------------------------
@@ -217,6 +219,31 @@ void post_display_init(void)
 {
     print_smbios_startup_info();
     print_smbus_startup_info();
+
+    if(false) {
+        // Try to get RAM information from IMC (TODO)
+        printf(8,0, "IMC: %uMHz (%s-%u) CAS %u-%u-%u-%u", ram.freq / 2
+                                                        , ram.type
+                                                        , ram.freq
+                                                        , ram.tCL
+                                                        , ram.tRCD
+                                                        , ram.tRP
+                                                        , ram.tRAS);
+        display_mode = 2;
+    } else if (ram.freq > 0 && ram.tCL > 1) {
+        // If not available, grab max memory specs from SPD
+        printf(8,0, "RAM: %uMHz (%s-%u) CAS %u-%u-%u-%u", ram.freq / 2
+                                                        , ram.type
+                                                        , ram.freq
+                                                        , ram.tCL
+                                                        , ram.tRCD
+                                                        , ram.tRP
+                                                        , ram.tRAS);
+        display_mode = 1;
+    } else {
+        // If nothing avilable, fallback to "Using Core" Display
+        display_mode = 0;
+    }
 }
 
 void display_start_run(void)

--- a/app/display.c
+++ b/app/display.c
@@ -89,15 +89,15 @@ void display_init(void)
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
     prints(0,28,                             "| ");
-    prints(1, 0, "CLK/Temp: N/A               | Pass   % ");
-    prints(2, 0, "L1 Cache: N/A               | Test   % ");
-    prints(3, 0, "L2 Cache: N/A               | Test #   ");
-    prints(4, 0, "L3 Cache: N/A               | Testing: ");
-    prints(5, 0, "Memory  : N/A               | Pattern: ");
-    prints(6, 0, "-------------------------------------------------------------------------------");
-    prints(7, 0, "CPU:                     SMP: N/A        | Time:           Status: Init. ");
-    prints(8, 0, "Using:                                   | Pass:           Errors: ");
-    prints(9, 0, "-------------------------------------------------------------------------------");
+    prints(1, 0, "CLK/Temp:   N/A             | Pass   % ");
+    prints(2, 0, "L1 Cache:   N/A             | Test   % ");
+    prints(3, 0, "L2 Cache:   N/A             | Test #   ");
+    prints(4, 0, "L3 Cache:   N/A             | Testing: ");
+    prints(5, 0, "Memory  :   N/A             | Pattern: ");
+    prints(6, 0, "--------------------------------------------------------------------------------");
+    prints(7, 0, "CPU:                     SMP: N/A         | Time:           Status: Init. ");
+    prints(8, 0, "Using:                                    | Pass:           Errors: ");
+    prints(9, 0, "--------------------------------------------------------------------------------");
 
     // Redraw lines using box drawing characters.
     // Disable if TTY is enabled to avoid VT100 char replacements
@@ -110,11 +110,11 @@ void display_init(void)
             print_char(i, 28, 0xb3);
         }
         for (int i = 7; i < 10; i++) {
-            print_char(i, 41, 0xb3);
+            print_char(i, 42, 0xb3);
         }
         print_char(6, 28, 0xc1);
-        print_char(6, 41, 0xc2);
-        print_char(9, 41, 0xc1);
+        print_char(6, 42, 0xc2);
+        print_char(9, 42, 0xc1);
     }
 
     set_foreground_colour(BLUE);

--- a/app/display.c
+++ b/app/display.c
@@ -73,7 +73,7 @@ void display_init(void)
 
     clear_screen();
 
-    set_foreground_colour(RED);
+    set_foreground_colour(BLACK);
     set_background_colour(WHITE);
     clear_screen_region(0, 0, 0, 27);
 #if TESTWORD_WIDTH > 32
@@ -81,6 +81,8 @@ void display_init(void)
 #else
     prints(0, 0, "  Memtest86+ v6.00pre (32b)");
 #endif
+    set_foreground_colour(RED);
+    printc(0, 11, '+');
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
     prints(0,28,                             "| ");

--- a/app/display.c
+++ b/app/display.c
@@ -64,6 +64,8 @@ static bool timed_update_done = false;  // update cycle status
 
 int scroll_message_row;
 
+int max_cpu_temp = 0;
+
 //------------------------------------------------------------------------------
 // Public Functions
 //------------------------------------------------------------------------------
@@ -347,7 +349,15 @@ void do_tick(int my_cpu)
 
         // Update temperature one time per second
         if (enable_temperature) {
-            display_temperature(get_cpu_temperature());
+            int actual_cpu_temp = get_cpu_temperature();
+
+            if(max_cpu_temp < actual_cpu_temp ) {
+                max_cpu_temp = actual_cpu_temp;
+            }
+
+            if(actual_cpu_temp != 0) {
+                display_temperature(actual_cpu_temp, max_cpu_temp);
+            }
         }
 
         // Update TTY one time every TTY_UPDATE_PERIOD second(s)

--- a/app/display.c
+++ b/app/display.c
@@ -91,8 +91,8 @@ void display_init(void)
     prints(4, 0, "L3 Cache: N/A               | Testing: ");
     prints(5, 0, "Memory  : N/A               | Pattern: ");
     prints(6, 0, "-------------------------------------------------------------------------------");
-    prints(7, 0, "CPU cores:     available,     enabled  | Time:            Temperature: N/A ");
-    prints(8, 0, "Run mode : PAR    Using:               | Pass:            Errors: ");
+    prints(7, 0, "CPU cores:     available,     enabled    | Time:           Status: Init. ");
+    prints(8, 0, "Run mode : PAR    Using:                 | Pass:           Errors: ");
     prints(9, 0, "-------------------------------------------------------------------------------");
 
     // Redraw lines using box drawing characters.
@@ -106,17 +106,17 @@ void display_init(void)
             print_char(i, 28, 0xb3);
         }
         for (int i = 7; i < 10; i++) {
-            print_char(i, 39, 0xb3);
+            print_char(i, 41, 0xb3);
         }
         print_char(6, 28, 0xc1);
-        print_char(6, 39, 0xc2);
-        print_char(9, 39, 0xc1);
+        print_char(6, 41, 0xc2);
+        print_char(9, 41, 0xc1);
     }
 
     set_foreground_colour(BLUE);
     set_background_colour(WHITE);
     clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
-    prints(ROW_FOOTER, 0, " <ESC> exit  <F1> configuration  <Space> scroll lock");
+    prints(ROW_FOOTER, 0, " <ESC> Exit  <F1> Configuration  <Space> Scroll Lock");
     prints(ROW_FOOTER, 64, "6.00.");
     prints(ROW_FOOTER, 69, GIT_HASH);
 #if TESTWORD_WIDTH > 32
@@ -179,9 +179,9 @@ void display_start_run(void)
         clear_message_area();
     }
 
-    clear_screen_region(7, 47, 7, 57);                  // run time
-    clear_screen_region(8, 47, 8, 57);                  // pass number
-    clear_screen_region(8, 66, 8, SCREEN_WIDTH - 1);    // error count
+    clear_screen_region(7, 49, 7, 57);                  // run time
+    clear_screen_region(8, 49, 8, 57);                  // pass number
+    clear_screen_region(8, 68, 8, SCREEN_WIDTH - 1);    // error count
     display_pass_count(0);
     display_error_count(0);
     if (clks_per_msec > 0) {
@@ -190,6 +190,7 @@ void display_start_run(void)
         next_spin_time = run_start_time + SPINNER_PERIOD * clks_per_msec;
     }
     display_spinner('-');
+    display_status("Testing");
 
     if (enable_tty){
         tty_full_redraw();

--- a/app/display.c
+++ b/app/display.c
@@ -137,11 +137,13 @@ void display_init(void)
     if (clks_per_msec) {
         display_cpu_clk((int)(clks_per_msec / 1000));
     }
+#if TESTWORD_WIDTH < 64
     if (cpuid_info.flags.lm) {
-        display_cpu_addr_mode("X64");
+        display_cpu_addr_mode(" [LM]");
     } else if (cpuid_info.flags.pae) {
-        display_cpu_addr_mode("PAE");
+        display_cpu_addr_mode("[PAE]");
     }
+#endif
     if (l1_cache) {
         display_l1_cache_size(l1_cache);
     }
@@ -281,7 +283,9 @@ void display_start_pass(void)
 
 void display_start_test(void)
 {
-    clear_screen_region(2, 39, 5, SCREEN_WIDTH - 1);    // progress bar, test details
+    clear_screen_region(2, 39, 3, SCREEN_WIDTH - 1);    // progress bar, test details
+    clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6);    // Avoid erasing paging mode
+    clear_screen_region(5, 39, 5, SCREEN_WIDTH - 1);
     clear_screen_region(3, 36, 3, 37);                  // test number
     display_test_percentage(0);
     display_test_number(test_num);

--- a/app/display.c
+++ b/app/display.c
@@ -83,7 +83,7 @@ void display_init(void)
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
     prints(0,28,                             "| ");
-    prints(1, 0, "CPU     : N/A               | Pass   % ");
+    prints(1, 0, "CLK/Temp: N/A               | Pass   % ");
     prints(2, 0, "L1 Cache: N/A               | Test   % ");
     prints(3, 0, "L2 Cache: N/A               | Test #   ");
     prints(4, 0, "L3 Cache: N/A               | Testing: ");

--- a/app/display.h
+++ b/app/display.h
@@ -38,9 +38,6 @@
 #define display_cpu_clk(freq) \
     printf(1, 10, "%i MHz", freq)
 
-#define display_cpu_addr_mode(str) \
-    prints(1, 20, str)
-
 #define display_l1_cache_size(size) \
     printf(2, 9, "%6kB", (uintptr_t)(size));
 
@@ -72,21 +69,12 @@
     dmicol = prints(23, dmicol, sys_man); \
     prints(23, dmicol + 1, sys_sku);
 
-#define display_available_cpus(count) \
-    printi(7, 10, count, 4, false, false)
-
-#define display_enabled_cpus(count) \
-    printi(7, 25, count, 4, false, false)
-
-#define display_cpu_mode(str) \
-    prints(8, 11, str)
-
 #define display_active_cpu(cpu_num) \
-    prints(8, 25, "core #"); \
-    printi(8, 31, cpu_num, 3, false, true)
+    prints(8, 7, "Core #"); \
+    printi(8, 13, cpu_num, 3, false, true)
 
 #define display_all_active \
-    prints(8, 25, "all cores")
+    prints(8, 7, "All Cores")
 
 #define display_spinner(spin_state) \
     printc(7, 76, spin_state)
@@ -195,6 +183,8 @@
 extern int scroll_message_row;
 
 void display_init(void);
+
+void display_cpu_topology(void);
 
 void post_display_init(void);
 

--- a/app/display.h
+++ b/app/display.h
@@ -146,7 +146,7 @@
     printf(7, 47, "%i:%02i:%02i", hours, mins, secs)
 
 #define display_temperature(temp) \
-    printf(7, 71, "%2i%cC   ", temp, 0xf8)
+    printf(1, 20, "%2i/%2i%cC", temp, temp, 0xf8)
 
 #define display_pass_count(count) \
     printi(8, 47, count, 0, false, true)

--- a/app/display.h
+++ b/app/display.h
@@ -145,8 +145,8 @@
 #define display_run_time(hours, mins, secs) \
     printf(7, 47, "%i:%02i:%02i", hours, mins, secs)
 
-#define display_temperature(temp) \
-    printf(1, 20, "%2i/%2i%cC", temp, temp, 0xf8)
+#define display_temperature(temp, maxtemp) \
+    printf(1, 20, "%2i/%2i%cC", temp, maxtemp, 0xf8)
 
 #define display_pass_count(count) \
     printi(8, 47, count, 0, false, true)

--- a/app/display.h
+++ b/app/display.h
@@ -65,6 +65,9 @@
 #define display_ram_speed(size) \
     printf(5, 18, "%S6kB/s", (uintptr_t)(size))
 
+#define display_status(status) \
+    prints(7, 67, status)
+
 #define display_dmi_mb(sys_ma, sys_sku) \
     dmicol = prints(23, dmicol, sys_man); \
     prints(23, dmicol + 1, sys_sku);
@@ -86,7 +89,7 @@
     prints(8, 25, "all cores")
 
 #define display_spinner(spin_state) \
-    printc(8, 36, spin_state)
+    printc(7, 76, spin_state)
 
 #define display_pass_percentage(pct) \
     printi(1, 34, pct, 3, false, false)
@@ -143,16 +146,16 @@
     }
 
 #define display_run_time(hours, mins, secs) \
-    printf(7, 47, "%i:%02i:%02i", hours, mins, secs)
+    printf(7, 50, "%i:%02i:%02i", hours, mins, secs)
 
 #define display_temperature(temp, maxtemp) \
     printf(1, 20, "%2i/%2i%cC", temp, maxtemp, 0xf8)
 
 #define display_pass_count(count) \
-    printi(8, 47, count, 0, false, true)
+    printi(8, 50, count, 0, false, true)
 
 #define display_error_count(count) \
-    printi(8, 66, count, 0, false, true)
+    printi(8, 67, count, 0, false, true);
 
 #define clear_message_area() \
     { \

--- a/app/display.h
+++ b/app/display.h
@@ -36,7 +36,7 @@
     prints(0, 30, str)
 
 #define display_cpu_clk(freq) \
-    printf(1, 10, "%i MHz", freq)
+    printf(1, 10, "%iMHz", freq)
 
 #define display_l1_cache_size(size) \
     printf(2, 9, "%6kB", (uintptr_t)(size));
@@ -63,7 +63,7 @@
     printf(5, 18, "%S6kB/s", (uintptr_t)(size))
 
 #define display_status(status) \
-    prints(7, 67, status)
+    prints(7, 68, status)
 
 #define display_dmi_mb(sys_ma, sys_sku) \
     dmicol = prints(23, dmicol, sys_man); \
@@ -77,7 +77,7 @@
     prints(8, 7, "All Cores")
 
 #define display_spinner(spin_state) \
-    printc(7, 76, spin_state)
+    printc(7, 77, spin_state)
 
 #define display_pass_percentage(pct) \
     printi(1, 34, pct, 3, false, false)
@@ -134,16 +134,16 @@
     }
 
 #define display_run_time(hours, mins, secs) \
-    printf(7, 50, "%i:%02i:%02i", hours, mins, secs)
+    printf(7, 51, "%i:%02i:%02i", hours, mins, secs)
 
 #define display_temperature(temp, maxtemp) \
     printf(1, 20, "%2i/%2i%cC", temp, maxtemp, 0xf8)
 
 #define display_pass_count(count) \
-    printi(8, 50, count, 0, false, true)
+    printi(8, 51, count, 0, false, true)
 
 #define display_error_count(count) \
-    printi(8, 67, count, 0, false, true);
+    printi(8, 68, count, 0, false, true);
 
 #define clear_message_area() \
     { \

--- a/app/display.h
+++ b/app/display.h
@@ -73,7 +73,7 @@
     prints(8, 7, "Core #"); \
     printi(8, 13, cpu_num, 3, false, true)
 
-#define display_all_active \
+#define display_all_active() \
     prints(8, 7, "All Cores")
 
 #define display_spinner(spin_state) \
@@ -181,6 +181,8 @@
     if (enable_trace) do_trace(my_cpu, __VA_ARGS__)
 
 extern int scroll_message_row;
+
+extern int display_mode;
 
 void display_init(void);
 

--- a/app/display.h
+++ b/app/display.h
@@ -9,6 +9,7 @@
  *
  *//*
  * Copyright (C) 2020-2022 Martin Whitaker.
+ * Copyright (C) 2004-2022 Sam Demeulemeester.
  */
 
 #include <stdbool.h>
@@ -38,6 +39,9 @@
 #define display_cpu_clk(freq) \
     printf(1, 10, "%iMHz", freq)
 
+#define display_cpu_addr_mode(str) \
+    prints(5, 76, str)
+
 #define display_l1_cache_size(size) \
     printf(2, 9, "%6kB", (uintptr_t)(size));
 
@@ -64,6 +68,31 @@
 
 #define display_status(status) \
     prints(7, 68, status)
+
+#define display_threading(nb, mode) \
+    printf(7,31, "%uT (%s)", nb, mode);
+
+#define display_threading_disabled() \
+    prints(7,31, "Disabled");
+
+#define display_cpu_topo_hybrid(nb) \
+    printf(7, 5, "%u Threads (Hybrid)", nb);
+
+#define display_cpu_topo_multi_socket(nbs, nbc, nbt) \
+    printf(7, 5, "%uS / %uC / %uT", nbs, nbc, nbt);
+
+#define display_cpu_topo(nbc, nbt) \
+    printf(7, 5, "%u Cores %u Threads", nbc, nbt);
+
+#define display_cpu_topo_short(nbc, nbt) \
+    printf(7, 5, "%u Cores (%uT)", nbc, nbt);
+
+#define display_spec_mode(mode) \
+    prints(8,0, mode);
+
+#define display_spec(freq, type, cl, rcd, rp, ras) \
+    printf(8,5, "%uMHz (%s-%u) CAS %u-%u-%u-%u", \
+                freq / 2, type, freq, cl, rcd, rp, ras);
 
 #define display_dmi_mb(sys_ma, sys_sku) \
     dmicol = prints(23, dmicol, sys_man); \
@@ -106,7 +135,7 @@
 #define display_test_addresses(pb, pe, total) \
     { \
         clear_screen_region(4, 39, 4, SCREEN_WIDTH - 1); \
-        printf(4, 39, "%kB - %kB    %kB of %kB", pb, pe, (pe) - (pb), total); \
+        printf(4, 39, "%kB - %kB [%kB of %kB]", pb, pe, (pe) - (pb), total); \
     }
 
 #define display_test_stage_description(...) \

--- a/app/display.h
+++ b/app/display.h
@@ -42,28 +42,28 @@
     prints(1, 20, str)
 
 #define display_l1_cache_size(size) \
-    printf(2, 10, "%kB", (uintptr_t)(size))
+    printf(2, 9, "%6kB", (uintptr_t)(size));
 
 #define display_l2_cache_size(size) \
-    printf(3, 10, "%kB", (uintptr_t)(size))
+    printf(3, 9, "%6kB", (uintptr_t)(size));
 
 #define display_l3_cache_size(size) \
-    printf(4, 10, "%kB", (uintptr_t)(size))
-
-#define display_l1_cache_speed(size) \
-    printf(2, 19, "%kB/s", (uintptr_t)(size))
-
-#define display_l2_cache_speed(size) \
-    printf(3, 19, "%kB/s", (uintptr_t)(size))
-
-#define display_l3_cache_speed(size) \
-    printf(4, 19, "%kB/s", (uintptr_t)(size))
-
-#define display_ram_speed(size) \
-    printf(5, 19, "%kB/s", (uintptr_t)(size))
+    printf(4, 9, "%6kB", (uintptr_t)(size));
 
 #define display_memory_size(size) \
-    printf(5, 10, "%kB", (uintptr_t)(size))
+    printf(5, 9, "%6kB", (uintptr_t)(size));
+
+#define display_l1_cache_speed(size) \
+    printf(2, 18, "%S6kB/s", (uintptr_t)(size))
+
+#define display_l2_cache_speed(size) \
+    printf(3, 18, "%S6kB/s", (uintptr_t)(size))
+
+#define display_l3_cache_speed(size) \
+    printf(4, 18, "%S6kB/s", (uintptr_t)(size))
+
+#define display_ram_speed(size) \
+    printf(5, 18, "%S6kB/s", (uintptr_t)(size))
 
 #define display_dmi_mb(sys_ma, sys_sku) \
     dmicol = prints(23, dmicol, sys_man); \

--- a/app/display.h
+++ b/app/display.h
@@ -46,7 +46,7 @@ typedef enum {
     printf(1, 10, "%iMHz", freq)
 
 #define display_cpu_addr_mode(str) \
-    prints(5, 76, str)
+    prints(4, 75, str)
 
 #define display_l1_cache_size(size) \
     printf(2, 9, "%6kB", (uintptr_t)(size))
@@ -140,13 +140,13 @@ typedef enum {
 
 #define display_test_addresses(pb, pe, total) \
     { \
-        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 1); \
+        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6); \
         printf(4, 39, "%kB - %kB [%kB of %kB]", pb, pe, (pe) - (pb), total); \
     }
 
 #define display_test_stage_description(...) \
     { \
-        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 1); \
+        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6); \
         printf(4, 39, __VA_ARGS__); \
     }
 

--- a/app/display.h
+++ b/app/display.h
@@ -33,6 +33,12 @@
 
 #define ERROR_LIMIT     UINT64_C(999999999999)
 
+typedef enum {
+    DISPLAY_MODE_NA,
+    DISPLAY_MODE_SPD,
+    DISPLAY_MODE_IMC
+} display_mode_t;
+
 #define display_cpu_model(str) \
     prints(0, 30, str)
 
@@ -43,49 +49,49 @@
     prints(5, 76, str)
 
 #define display_l1_cache_size(size) \
-    printf(2, 9, "%6kB", (uintptr_t)(size));
+    printf(2, 9, "%6kB", (uintptr_t)(size))
 
 #define display_l2_cache_size(size) \
-    printf(3, 9, "%6kB", (uintptr_t)(size));
+    printf(3, 9, "%6kB", (uintptr_t)(size))
 
 #define display_l3_cache_size(size) \
-    printf(4, 9, "%6kB", (uintptr_t)(size));
+    printf(4, 9, "%6kB", (uintptr_t)(size))
 
 #define display_memory_size(size) \
-    printf(5, 9, "%6kB", (uintptr_t)(size));
+    printf(5, 9, "%6kB", (uintptr_t)(size))
 
-#define display_l1_cache_speed(size) \
-    printf(2, 18, "%S6kB/s", (uintptr_t)(size))
+#define display_l1_cache_speed(speed) \
+    printf(2, 18, "%S6kB/s", (uintptr_t)(speed))
 
-#define display_l2_cache_speed(size) \
-    printf(3, 18, "%S6kB/s", (uintptr_t)(size))
+#define display_l2_cache_speed(speed) \
+    printf(3, 18, "%S6kB/s", (uintptr_t)(speed))
 
-#define display_l3_cache_speed(size) \
-    printf(4, 18, "%S6kB/s", (uintptr_t)(size))
+#define display_l3_cache_speed(speed) \
+    printf(4, 18, "%S6kB/s", (uintptr_t)(speed))
 
-#define display_ram_speed(size) \
-    printf(5, 18, "%S6kB/s", (uintptr_t)(size))
+#define display_ram_speed(speed) \
+    printf(5, 18, "%S6kB/s", (uintptr_t)(speed))
 
 #define display_status(status) \
     prints(7, 68, status)
 
 #define display_threading(nb, mode) \
-    printf(7,31, "%uT (%s)", nb, mode);
+    printf(7,31, "%uT (%s)", nb, mode)
 
 #define display_threading_disabled() \
-    prints(7,31, "Disabled");
+    prints(7,31, "Disabled")
 
-#define display_cpu_topo_hybrid(nb) \
-    printf(7, 5, "%u Threads (Hybrid)", nb);
+#define display_cpu_topo_hybrid(num_threads) \
+    printf(7, 5, "%u Threads (Hybrid)", num_threads)
 
-#define display_cpu_topo_multi_socket(nbs, nbc, nbt) \
-    printf(7, 5, "%uS / %uC / %uT", nbs, nbc, nbt);
+#define display_cpu_topo_multi_socket(num_sockets, num_cores, num_threads) \
+    printf(7, 5, "%uS / %uC / %uT", num_sockets, num_cores, num_threads)
 
-#define display_cpu_topo(nbc, nbt) \
-    printf(7, 5, "%u Cores %u Threads", nbc, nbt);
+#define display_cpu_topo( num_cores, num_threads) \
+    printf(7, 5, "%u Cores %u Threads", num_cores, num_threads)
 
-#define display_cpu_topo_short(nbc, nbt) \
-    printf(7, 5, "%u Cores (%uT)", nbc, nbt);
+#define display_cpu_topo_short( num_cores, num_threads) \
+    printf(7, 5, "%u Cores (%uT)",  num_cores, num_threads)
 
 #define display_spec_mode(mode) \
     prints(8,0, mode);
@@ -172,7 +178,7 @@
     printi(8, 51, count, 0, false, true)
 
 #define display_error_count(count) \
-    printi(8, 68, count, 0, false, true);
+    printi(8, 68, count, 0, false, true)
 
 #define clear_message_area() \
     { \
@@ -211,7 +217,7 @@
 
 extern int scroll_message_row;
 
-extern int display_mode;
+extern display_mode_t display_mode;
 
 void display_init(void);
 

--- a/app/error.c
+++ b/app/error.c
@@ -367,6 +367,7 @@ void error_update(void)
                                    test_list[test_num].errors);
         }
         display_error_count(error_count);
+        display_status("Failed!");
 
         if (enable_tty) {
             tty_error_redraw();

--- a/app/main.c
+++ b/app/main.c
@@ -622,6 +622,7 @@ void main(void)
         if (!dummy_run) {
             display_pass_count(pass_num);
             if (error_count == 0) {
+                display_status("Pass   ");
                 display_notice("** Pass completed, no errors **");
             }
         }

--- a/app/main.c
+++ b/app/main.c
@@ -67,8 +67,6 @@
 
 static volatile int     init_state = 0;
 
-static int              num_enabled_cpus = 1;
-
 static uintptr_t        low_load_addr;
 static uintptr_t        high_load_addr;
 
@@ -100,6 +98,7 @@ efi_info_t  saved_efi_info;
 uint8_t     chunk_index[MAX_CPUS];
 
 int         num_active_cpus = 0;
+int         num_enabled_cpus = 1;
 
 int         master_cpu = 0;
 
@@ -230,8 +229,6 @@ static void global_init(void)
 
     clear_message_area();
 
-    display_available_cpus(num_available_cpus);
-
     num_enabled_cpus = 0;
     for (int i = 0; i < num_available_cpus; i++) {
         if (cpu_state[i] == CPU_STATE_ENABLED) {
@@ -239,7 +236,7 @@ static void global_init(void)
             num_enabled_cpus++;
         }
     }
-    display_enabled_cpus(num_enabled_cpus);
+    display_cpu_topology();
 
     master_cpu = 0;
 

--- a/app/main.c
+++ b/app/main.c
@@ -346,9 +346,13 @@ static void test_all_windows(int my_cpu)
         if (!dummy_run) {
             if (parallel_test) {
                 num_active_cpus = num_enabled_cpus;
-                display_all_active;
+                if(display_mode == 0) {
+                    display_all_active();
+                }
             } else {
-                display_active_cpu(my_cpu);
+                if(display_mode == 0) {
+                    display_active_cpu(my_cpu);
+                }
             }
         }
         barrier_reset(run_barrier, num_active_cpus);

--- a/app/main.c
+++ b/app/main.c
@@ -246,7 +246,7 @@ static void global_init(void)
     if (enable_temperature) {
         int temp = get_cpu_temperature();
         if (temp > 0) {
-            display_temperature(temp);
+            display_temperature(temp, temp);
         } else {
             enable_temperature = false;
             no_temperature = true;

--- a/app/main.c
+++ b/app/main.c
@@ -346,11 +346,11 @@ static void test_all_windows(int my_cpu)
         if (!dummy_run) {
             if (parallel_test) {
                 num_active_cpus = num_enabled_cpus;
-                if(display_mode == 0) {
+                if(display_mode == DISPLAY_MODE_NA) {
                     display_all_active();
                 }
             } else {
-                if(display_mode == 0) {
+                if (display_mode == 0) {
                     display_active_cpu(my_cpu);
                 }
             }

--- a/build32/Makefile
+++ b/build32/Makefile
@@ -1,10 +1,18 @@
 AS = as -32
 CC = gcc
 
+GIT = git
+
+ifeq ($(GIT),none)
+  GIT_AVAILABLE = false
+else
+  GIT_AVAILABLE = true
+endif
+
 CFLAGS = -std=c11 -Wall -Wextra -Wshadow -m32 -march=i586 -fpic -fno-builtin \
          -ffreestanding -fomit-frame-pointer -fno-stack-protector
 
-INC_DIRS = -I../boot -I../system -I../lib -I../tests -I../app
+INC_DIRS = -I../boot -I../system -I../lib -I../tests -I../app -Iapp
 
 SYS_OBJS = system/cpuid.o \
            system/cpuinfo.o \
@@ -94,14 +102,23 @@ tests/%.o: ../tests/%.c
 	@mkdir -p tests
 	$(CC) -c $(CFLAGS) -O3 $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-app/%.o: ../app/%.c githash.h
+app/%.o: ../app/%.c app/githash.h
 	@mkdir -p app
 	$(CC) -c $(CFLAGS) -Os $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-githash.h:
-	echo  -n '#ifndef GIT_HASH\n#define GIT_HASH "' > ../app/$@ && \
-	git rev-parse HEAD | cut -c1-7 | tr -d "\n" >> ../app/$@ && \
-	echo  '"\n#endif' >> ../app/$@
+app/githash.h: FORCE
+	@mkdir -p app
+	@( \
+	  if $(GIT_AVAILABLE) && test -d ../.git ; then \
+	    hash=`git rev-parse HEAD | cut -c1-7`; \
+	  else \
+	    hash="unknown"; \
+	  fi; \
+	  define=`echo "#define GIT_HASH \"$$hash\""`; \
+	  echo $$define | diff - $@ > /dev/null 2>&1 || echo $$define > $@; \
+	)
+
+FORCE:
 
 # Link it statically once so I know I don't have undefined symbols and
 # then link it dynamically so I have full relocation information.

--- a/build32/Makefile
+++ b/build32/Makefile
@@ -94,9 +94,14 @@ tests/%.o: ../tests/%.c
 	@mkdir -p tests
 	$(CC) -c $(CFLAGS) -O3 $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-app/%.o: ../app/%.c
+app/%.o: ../app/%.c githash.h
 	@mkdir -p app
 	$(CC) -c $(CFLAGS) -Os $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
+
+githash.h:
+	echo  -n '#ifndef GIT_HASH\n#define GIT_HASH "' > ../app/$@ && \
+	git rev-parse HEAD | cut -c1-7 | tr -d "\n" >> ../app/$@ && \
+	echo  '"\n#endif' >> ../app/$@
 
 # Link it statically once so I know I don't have undefined symbols and
 # then link it dynamically so I have full relocation information.

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -93,9 +93,14 @@ tests/%.o: ../tests/%.c
 	@mkdir -p tests
 	$(CC) -c $(CFLAGS) -O3 $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-app/%.o: ../app/%.c
+app/%.o: ../app/%.c githash.h
 	@mkdir -p app
 	$(CC) -c $(CFLAGS) -Os $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
+
+githash.h:
+	echo  -n '#ifndef GIT_HASH\n#define GIT_HASH "' > ../app/$@ && \
+	git rev-parse HEAD | cut -c1-7 | tr -d "\n" >> ../app/$@ && \
+	echo  '"\n#endif' >> ../app/$@
 
 # Link it statically once so I know I don't have undefined symbols and
 # then link it dynamically so I have full relocation information.

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -1,10 +1,18 @@
 AS = as -64
 CC = gcc
 
+GIT = git
+
+ifeq ($(GIT),none)
+  GIT_AVAILABLE = false
+else
+  GIT_AVAILABLE = true
+endif
+
 CFLAGS = -std=c11 -Wall -Wextra -Wshadow -m64 -march=x86-64 -mno-mmx -mno-sse -mno-sse2 \
          -fpic -fno-builtin -ffreestanding -fomit-frame-pointer -fno-stack-protector
 
-INC_DIRS = -I../boot -I../system -I../lib -I../tests -I../app
+INC_DIRS = -I../boot -I../system -I../lib -I../tests -I../app -Iapp
 
 SYS_OBJS = system/cpuid.o \
            system/cpuinfo.o \
@@ -93,14 +101,23 @@ tests/%.o: ../tests/%.c
 	@mkdir -p tests
 	$(CC) -c $(CFLAGS) -O3 $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-app/%.o: ../app/%.c githash.h
+app/%.o: ../app/%.c app/githash.h
 	@mkdir -p app
 	$(CC) -c $(CFLAGS) -Os $(INC_DIRS) -o $@ $< -MMD -MP -MT $@ -MF $(@:.o=.d)
 
-githash.h:
-	echo  -n '#ifndef GIT_HASH\n#define GIT_HASH "' > ../app/$@ && \
-	git rev-parse HEAD | cut -c1-7 | tr -d "\n" >> ../app/$@ && \
-	echo  '"\n#endif' >> ../app/$@
+app/githash.h: FORCE
+	@mkdir -p app
+	@( \
+	  if $(GIT_AVAILABLE) && test -d ../.git ; then \
+	    hash=`git rev-parse HEAD | cut -c1-7`; \
+	  else \
+	    hash="unknown"; \
+	  fi; \
+	  define=`echo "#define GIT_HASH \"$$hash\""`; \
+	  echo $$define | diff - $@ > /dev/null 2>&1 || echo $$define > $@; \
+	)
+
+FORCE:
 
 # Link it statically once so I know I don't have undefined symbols and
 # then link it dynamically so I have full relocation information.

--- a/lib/print.c
+++ b/lib/print.c
@@ -148,7 +148,7 @@ int printx(int row, int col, uintptr_t value, int field_length, bool pad, bool l
     return print_in_field(row, col, buffer, -length, field_length, left);
 }
 
-int printk(int row, int col, uintptr_t value, int field_length, bool pad, bool left)
+int printk(int row, int col, uintptr_t value, int field_length, bool pad, bool left, bool add_space)
 {
     static const char suffix[4] = { 'K', 'M', 'G', 'T' };
 
@@ -186,6 +186,11 @@ int printk(int row, int col, uintptr_t value, int field_length, bool pad, bool l
 
     int length = 0;
     buffer[length++] = suffix[scale];
+
+    if(add_space) {
+        buffer[length++] = ' ';
+    }
+
     if (fract_length > 0) {
         length += int_to_dec_str(&buffer[length], fract, fract_length, fract_length);
         buffer[length++] = '.';
@@ -219,11 +224,16 @@ int vprintf(int row, int col, const char *fmt, va_list args)
             continue;
         }
 
-        bool pad   = false;
-        bool left  = false;
+        bool pad        = false;
+        bool left       = false;
+        bool add_space  = false;
         int length = 0;
         if (*fmt == '-') {
             left = true;
+            fmt++;
+        }
+        if (*fmt == 'S') {
+            add_space = true;
             fmt++;
         }
         if (*fmt == '0') {
@@ -263,7 +273,7 @@ int vprintf(int row, int col, const char *fmt, va_list args)
             col = printx(row, col, va_arg(args, uintptr_t), length, pad, left);
             break;
           case 'k':
-            col = printk(row, col, va_arg(args, uintptr_t), length, pad, left);
+            col = printk(row, col, va_arg(args, uintptr_t), length, pad, left, add_space);
             break;
         }
         fmt++;

--- a/lib/print.h
+++ b/lib/print.h
@@ -52,11 +52,13 @@ int printx(int row, int col, uintptr_t value, int length, bool pad, bool left);
 /**
  * Prints a K<unit> value on screen starting at location (row,col) in a field of
  * at least length characters, optionally padding the number with leading zeros,
- * and optionally left-justifying instead of right-justifying in the field. The
- * value is shown to 3 significant figures in the nearest K/M/G/T units. Returns
- * the next column after the formatted value.
+ * optionally left-justifying instead of right-justifying in the field, and
+ * optionnaly adding a space between number and unit. The value is shown to
+ * 3 significant figures in the nearest K/M/G/T units. Returns the next column
+ * after the formatted value.
  */
-int printk(int row, int col, uintptr_t value, int length, bool pad, bool left);
+int printk(int row, int col, uintptr_t value, int length,
+           bool pad, bool left, bool add_space);
 
 /**
  * Emulates the standard printf function. Printing starts at location (row,col).
@@ -64,6 +66,7 @@ int printk(int row, int col, uintptr_t value, int length, bool pad, bool left);
  * The conversion flags supported are:
  *   -  left justify
  *   0  pad with leading zeros
+ *   S  add space between number and unit (k specifier only)
  *
  * The conversion specifiers supported are:
  *   c  character (int type)

--- a/lib/print.h
+++ b/lib/print.h
@@ -53,7 +53,7 @@ int printx(int row, int col, uintptr_t value, int length, bool pad, bool left);
  * Prints a K<unit> value on screen starting at location (row,col) in a field of
  * at least length characters, optionally padding the number with leading zeros,
  * optionally left-justifying instead of right-justifying in the field, and
- * optionnaly adding a space between number and unit. The value is shown to
+ * optionally adding a space between number and unit. The value is shown to
  * 3 significant figures in the nearest K/M/G/T units. Returns the next column
  * after the formatted value.
  */

--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (C) 2020-2022 Martin Whitaker.
+// Copyright (C) 2004-2022 Sam Demeulemeester.
 //
 // Derived from memtest86+ cpuid.h
-// (original contained no copyright statement)
+
 
 #include <stdint.h>
 
 #include "cpuid.h"
+#include "display.h"
 
 //------------------------------------------------------------------------------
 // Public Variables
@@ -20,7 +22,7 @@ cpuid_info_t cpuid_info;
 
 void cpuid_init(void)
 {
-    uint32_t dummy[3];
+    uint32_t reg[4];
     char *p, *q;
 
     // Get the max standard cpuid & vendor ID.
@@ -46,26 +48,26 @@ void cpuid_init(void)
     if (cpuid_info.max_cpuid >= 6) {
         cpuid(0x6, 0,
             &cpuid_info.dts_pmp,
-            &dummy[0],
-            &dummy[1],
-            &dummy[2]
+            &reg[0],
+            &reg[1],
+            &reg[2]
         );
     }
 
     // Get the max extended cpuid.
     cpuid(0x80000000, 0,
         &cpuid_info.max_xcpuid,
-        &dummy[0],
-        &dummy[1],
-        &dummy[2]
+        &reg[0],
+        &reg[1],
+        &reg[2]
     );
 
     // Get extended feature flags, only save EDX.
     if (cpuid_info.max_xcpuid >= 0x80000001) {
         cpuid(0x80000001, 0,
-            &dummy[0],
-            &dummy[1],
-            &dummy[2],
+            &reg[0],
+            &reg[1],
+            &reg[2],
             &cpuid_info.flags.raw[2]
         );
     }
@@ -112,16 +114,16 @@ void cpuid_init(void)
         // AMD Processors
         if (cpuid_info.max_xcpuid >= 0x80000005) {
             cpuid(0x80000005, 0,
-                &dummy[0],
-                &dummy[1],
+                &reg[0],
+                &reg[1],
                 &cpuid_info.cache_info.raw[0],
                 &cpuid_info.cache_info.raw[1]
             );
         }
         if (cpuid_info.max_xcpuid >= 0x80000006) {
             cpuid(0x80000006, 0,
-                &dummy[0],
-                &dummy[1],
+                &reg[0],
+                &reg[1],
                 &cpuid_info.cache_info.raw[2],
                 &cpuid_info.cache_info.raw[3]
             );
@@ -130,6 +132,86 @@ void cpuid_init(void)
       case 'G':
         // Intel Processors
         // No cpuid info to read.
+        break;
+    }
+
+    // Detect CPU Topology (Core/Thread) infos
+    cpuid_info.topology.core_count   = -1;
+    cpuid_info.topology.thread_count = -1;
+    cpuid_info.topology.is_hybrid    =  0;
+    cpuid_info.topology.ecore_count  = -1;
+    cpuid_info.topology.pcore_count  = -1;
+
+    int thread_per_core = 1;
+
+    switch (cpuid_info.vendor_id.str[0]) {
+      case 'A':
+        // AMD Processors
+        if (cpuid_info.max_xcpuid >= 0x80000008) {
+
+            cpuid(0x80000008, 0, &reg[0], &reg[1], &reg[2], &reg[3]);
+            cpuid_info.topology.thread_count = (reg[2] & 0xFF) + 1;
+
+            if (cpuid_info.max_xcpuid >= 0x8000001E) {
+                cpuid(0x8000001E, 0, &reg[0], &reg[1], &reg[2], &reg[3]);
+
+                if (((reg[1] >> 8) & 0x3) > 0) {
+                    thread_per_core = 2;
+                }
+            } else if (cpuid_info.flags.htt) {
+                thread_per_core = 2;
+            }
+            cpuid_info.topology.core_count = cpuid_info.topology.thread_count / thread_per_core;
+        }
+        break;
+       case 'C':
+        // VIA / CentaurHauls
+        break;
+       case 'G':
+        if (cpuid_info.vendor_id.str[7] == 'T') break; // Transmeta
+        // Intel
+        if (cpuid_info.max_cpuid >= 0xB) {
+
+            // Populate Hybrid Status (CPUID 7.EDX[15]) for Alder Lake+
+            cpuid(0x7, 0, &reg[0], &reg[1], &reg[2], &reg[3]);
+            if (reg[3] & (1 << 15)) {
+                cpuid_info.topology.is_hybrid = 1;
+            }
+
+            for (int i=0; i < 4; i++) {
+                cpuid(0xB, i, &reg[0], &reg[1], &reg[2], &reg[3]);
+
+                switch((reg[2] >> 8) & 0xFF) {
+                    case 1: // SMT
+                        thread_per_core = reg[1] & 0xFF;
+                        break;
+                    case 2: // Cores
+                        cpuid_info.topology.thread_count = reg[1] & 0xFFFF;
+                        break;
+                    default:
+                        continue;
+                }
+            }
+
+            cpuid_info.topology.core_count = cpuid_info.topology.thread_count / thread_per_core;
+
+        } else if (cpuid_info.max_cpuid >= 0x4) {
+            cpuid(4, 0, &reg[0], &reg[1], &reg[2], &reg[3]);
+
+            cpuid_info.topology.core_count = (reg[0] >> 26) + 1;
+            cpuid_info.topology.thread_count = cpuid_info.topology.core_count;
+
+            if (cpuid_info.flags.htt){
+                cpuid_info.topology.thread_count *= 2;
+            }
+        } else if (cpuid_info.max_cpuid >= 0x2) {
+            if(cpuid_info.flags.htt){
+                cpuid_info.topology.core_count = 1;
+                cpuid_info.topology.thread_count = 2;
+            }
+        }
+        break;
+      default:
         break;
     }
 }

--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 #include "cpuid.h"
-#include "display.h"
 
 //------------------------------------------------------------------------------
 // Public Variables

--- a/system/cpuid.h
+++ b/system/cpuid.h
@@ -8,9 +8,9 @@
  *
  *//*
  * Copyright (C) 2020-2022 Martin Whitaker.
+ * Copyright (C) 2004-2022 Sam Demeulemeester.
  *
  * Derived from memtest86+ cpuid.h
- * (original contained no copyright statement)
  */
 
 #include <stdint.h>
@@ -134,6 +134,14 @@ typedef union {
 } cpuid_custom_features;
 
 typedef struct {
+    int     core_count;
+    int     thread_count;
+    int     is_hybrid;
+    int     ecore_count;
+    int     pcore_count;
+} topology_t;
+
+typedef struct {
     uint32_t                max_cpuid;
     uint32_t                max_xcpuid;
     uint32_t                dts_pmp;
@@ -144,6 +152,7 @@ typedef struct {
     cpuid_brand_string_t    brand_id;
     cpuid_cache_info_t      cache_info;
     cpuid_custom_features   custom;
+    topology_t              topology;
 } cpuid_info_t;
 
 typedef union {

--- a/system/cpuid.h
+++ b/system/cpuid.h
@@ -139,7 +139,7 @@ typedef struct {
     int     is_hybrid;
     int     ecore_count;
     int     pcore_count;
-} topology_t;
+} cpuid_topology_t;
 
 typedef struct {
     uint32_t                max_cpuid;
@@ -152,7 +152,7 @@ typedef struct {
     cpuid_brand_string_t    brand_id;
     cpuid_cache_info_t      cache_info;
     cpuid_custom_features   custom;
-    topology_t              topology;
+    cpuid_topology_t        topology;
 } cpuid_info_t;
 
 typedef union {

--- a/system/serial.c
+++ b/system/serial.c
@@ -184,8 +184,8 @@ void tty_send_region(int start_row, int start_col, int end_row, int end_col)
         }
 
         // Replace degree symbol with '*' for tty to avoid a C437/VT100 translation table.
-        if (row == 7 && col_len > 77 && (shadow_buffer[7][73].value & 0xFF) == 0xF8) {
-            p[73] = 0x2A;
+        if (row == 1 && (shadow_buffer[1][25].value & 0xFF) == 0xF8) {
+            p[25] = 0x2A;
         }
 
         // Send row to TTY

--- a/system/serial.h
+++ b/system/serial.h
@@ -149,7 +149,8 @@ struct serial_port {
 
 #define tty_partial_redraw() \
     tty_send_region(1, 34, 5, 79); \
-    tty_send_region(7, 0, 8, 79);
+    tty_send_region(7, 0, 8, 79); \
+    if(enable_temperature) tty_send_region(1, 16, 1, 26);
 
 #define tty_error_redraw() \
     tty_send_region(10, 0, 23, 79);

--- a/system/smbus.h
+++ b/system/smbus.h
@@ -63,7 +63,6 @@ typedef struct spd_infos {
     bool        isValid;
     uint32_t    module_size;
     uint8_t     slot_num;
-    char        *type;
     uint16_t    jedec_code;
     char        sku[32];
     uint8_t     sku_len;
@@ -72,7 +71,24 @@ typedef struct spd_infos {
     bool        hasECC;
     uint8_t     fab_year;
     uint8_t     fab_week;
+    uint16_t    tCL;
+    uint16_t    tRCD;
+    uint16_t    tRP;
+    uint16_t    tRAS;
+    uint16_t    tRC;
+    char        *type;
 } spd_info;
+
+typedef struct ram_infos {
+    uint16_t    freq;
+    uint16_t    tCL;
+    uint16_t    tRCD;
+    uint16_t    tRP;
+    uint16_t    tRAS;
+    char        *type;
+} ram_info;
+
+extern ram_info ram;
 
 #define get_spd(smb_idx, slot_idx, spd_adr) \
     smbcontrollers[smb_idx].read_spd_byte(slot_idx, spd_adr)


### PR DESCRIPTION
It's time to rebase the branch before the plugfest next week.
I tried to create the better mix possible based on all feedbacks. The biggest changes are on line 8/9. 
Others changes are on spacing, alignment, title color, temperature (max & current), update timer and build number addition.
Code has been added for timing detection (with support for XMP3.0/2.0/1.0 and EPP)

Line 8 now displays CPU Topology (Socket/Core/Thread) and Threading Status (SMP).
Line 9 now displays the most accurate specs as possible :
  1. The actual RAM frequency / Timings from the IMC (will be added later)
  2. If not available, the max RAM frequency/timings possible from SPD (implemented for DDR1->5)
  3. If not available, the Core actually being used for testing (as last resort fallback)

There is some TODO remaining but nothing critical:
- Hybrid CPU (ADL+) topology must be detected with e-core/p-core distinction, but that require a full SMP enumeration
- On DDR1, non integer timings (especially CAS) are not supported (will be rounded to nearest int)
- Last minute: paging mode (X64/PAE) is erased after being displayed and will be re-added soon.

The only information missing in some case is the actual CPU used. It's now only displayed by default if RAM frequency/timing is not detected. It's probably not a big deal, but it can be re-added at the end of line 6 if really needed.