### PR TITLE
Added a new usb_debug flag, slighly changed startup timing strategy

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -96,6 +96,7 @@ bool            enable_sm          = true;
 bool            enable_bench       = true;
 
 bool            pause_at_start     = true;
+bool            pause_usb_debug    = false;
 
 power_save_t    power_save         = POWER_SAVE_HIGH;
 
@@ -881,7 +882,7 @@ void initial_config(void)
     bool smp_init_done = false;
     if (pause_at_start) {
         bool got_key = false;
-        for (int i = 0; i < 5000 && !got_key; i++) {
+        for (int i = 0; i < 3000 && !got_key; i++) {
             usleep(1000);
             switch (get_key()) {
               case ESC:

--- a/app/config.h
+++ b/app/config.h
@@ -55,6 +55,7 @@ extern bool         enable_tty;
 extern bool         enable_bench;
 
 extern bool         pause_at_start;
+extern bool         pause_usb_debug;
 
 extern power_save_t power_save;
 

--- a/app/main.c
+++ b/app/main.c
@@ -219,7 +219,7 @@ static void global_init(void)
 
     config_init();
 
-    keyboard_init(pause_at_start);
+    keyboard_init(pause_usb_debug);
 
     display_init();
 

--- a/system/usbhcd.c
+++ b/system/usbhcd.c
@@ -26,6 +26,8 @@
 
 #define MILLISEC                1000    // in microseconds
 
+#define MAX_WAIT_NO_USB_FOUND   10      // in seconds
+
 //------------------------------------------------------------------------------
 // Types
 //------------------------------------------------------------------------------
@@ -506,7 +508,7 @@ bool assign_usb_address(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num
     return true;
 }
 
-bool find_attached_usb_keyboards(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num, 
+bool find_attached_usb_keyboards(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num,
                                  usb_speed_t device_speed, int device_id, int *num_devices,
                                  usb_ep_t keyboards[], int max_keyboards, int *num_keyboards)
 {
@@ -681,7 +683,7 @@ static void probe_usb_controller(int bus, int dev, int func, hci_type_t controll
 // Public Functions
 //------------------------------------------------------------------------------
 
-void find_usb_keyboards(bool pause_at_end)
+void find_usb_keyboards(bool usb_debug)
 {
     clear_screen();
     print_usb_info("Scanning for USB keyboards...");
@@ -738,9 +740,17 @@ void find_usb_keyboards(bool pause_at_end)
         }
     }
 
-    if (pause_at_end) {
+    if (usb_debug) {
         print_usb_info("Press any key to continue...");
         while (get_key() == 0) {}
+    } else if (num_usb_controllers == 0) {
+        for (int i = MAX_WAIT_NO_USB_FOUND * 1000; i > 0; i--) {
+            usleep(1000);
+            if (i % 1000 == 0) {
+                printf(print_row,0, "No USB Keyboard Found! Continue in %u second%s...", i/1000, (i>1000)?"s":" ");
+            }
+        }
+        print_row++;
     }
 }
 


### PR DESCRIPTION
Hi Martin, can you please check if these small changes are OK for you?

Here are the changes:

- `pause_at_start` is now unrelated to USB detection and only used for the initial configuration
- `pause_at_start` has been reduced from 5 to 3 seconds
- A new flag called `pause_usb_debug` (disabled by default) will force an infinite delay after USB detection (until keypress, as previously)
- In default mode (`pause_usb_debug` = false), if an USB keyboard is found, the USB detection routine will immediately continue to the initial `pause_at_start`. If no USB keyboard is detected, a 10 seconds timer will begin before continue. That will allow users with a keyboard issue to take a screenshot while allowing the test to continue without waiting for an impossible keypress.