### PR TITLE
Optimize screen & serial output handling.

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -80,42 +80,43 @@ void display_init(void)
 
     clear_screen();
 
+    /* The commented horizontal lines provide visual cue for where and how
+     * they will appear on the screen. They are drawn down below using
+     * Extended ASCII characters.
+     */
+
     set_foreground_colour(BLACK);
     set_background_colour(WHITE);
     clear_screen_region(0, 0, 0, 27);
-    prints(0, 0, "     Memtest86+ v6.00b1");
+    prints(0, 5,      "Memtest86+ v6.00b1");
     set_foreground_colour(RED);
     printc(0, 14, '+');
     set_foreground_colour(WHITE);
     set_background_colour(BLUE);
-    prints(0,28,                             "| ");
-    prints(1, 0, "CLK/Temp:   N/A             | Pass   % ");
-    prints(2, 0, "L1 Cache:   N/A             | Test   % ");
-    prints(3, 0, "L2 Cache:   N/A             | Test #   ");
-    prints(4, 0, "L3 Cache:   N/A             | Testing: ");
-    prints(5, 0, "Memory  :   N/A             | Pattern: ");
-    prints(6, 0, "--------------------------------------------------------------------------------");
-    prints(7, 0, "CPU:                      SMP: N/A        | Time:           Status: Init. ");
-    prints(8, 0, "Using:                                    | Pass:           Errors: ");
-    prints(9, 0, "--------------------------------------------------------------------------------");
+    prints(1, 0, "CLK/Temp:   N/A             | Pass   %");
+    prints(2, 0, "L1 Cache:   N/A             | Test   %");
+    prints(3, 0, "L2 Cache:   N/A             | Test #");
+    prints(4, 0, "L3 Cache:   N/A             | Testing:");
+    prints(5, 0, "Memory  :   N/A             | Pattern:");
+//  prints(6, 0, "--------------------------------------------------------------------------------");
+    prints(7, 0, "CPU:                      SMP: N/A        | Time:           Status: Init.");
+    prints(8, 0, "Using:                                    | Pass:           Errors:");
+//  prints(9, 0, "--------------------------------------------------------------------------------");
 
-    // Redraw lines using box drawing characters.
-    // Disable if TTY is enabled to avoid VT100 char replacements
-    if (!enable_tty) {
-        for (int i = 0;i < 80; i++) {
-            print_char(6, i, 0xc4);
-            print_char(9, i, 0xc4);
-        }
-        for (int i = 0; i < 6; i++) {
-            print_char(i, 28, 0xb3);
-        }
-        for (int i = 7; i < 10; i++) {
-            print_char(i, 42, 0xb3);
-        }
-        print_char(6, 28, 0xc1);
-        print_char(6, 42, 0xc2);
-        print_char(9, 42, 0xc1);
+    for (int i = 0;i < 80; i++) {
+        print_char(6, i, 0xc4);
+        print_char(9, i, 0xc4);
     }
+    for (int i = 0; i < 6; i++) {
+        print_char(i, 28, 0xb3);
+    }
+    for (int i = 7; i < 10; i++) {
+        print_char(i, 42, 0xb3);
+    }
+
+    print_char(6, 28, 0xc1);
+    print_char(6, 42, 0xc2);
+    print_char(9, 42, 0xc1);
 
     set_foreground_colour(BLUE);
     set_background_colour(WHITE);


### PR DESCRIPTION
 - Enable VGA/FB to output box drawing characters while maintaining VT100
   character set for serial. Shorten and simplify the screen setup code.

 - Track the background color to decide if the serial output needs to be
   inverted. Remove no longer needed logic for known areas of the screen that
   need to be inverted. As a bonus - popup menu can now be also inverted on
   serial.

 - Reduce the amount of data sent to serial by using CR+LF when possible
   instead of always relying on absolute positioning. Add tty_print()
   for positioning the cursor, remove no longer needed tty_print().

 - Remove no longer needed "LF -> LF+CR" logic from serial_echo_print().

```
Before (gcc-11.3.0-x86_64):
      text       data        bss      total filename
       929        357         64       1350 system/serial.o
      3517       1356         54       4927 app/display.o

After (gcc-11.3.0-x86_64):
      text       data        bss      total filename
       907        336         64       1307 system/serial.o
      3442       1242         54       4738 app/display.o
```
![memtest-serial](https://user-images.githubusercontent.com/105136494/169710994-f039e425-2249-4619-9f53-7785752788a6.png)

