### PR TITLE
Enable support for NV MCP61 (10de:03eb) SMBus controller

### DIFF
--- a/system/smbus.c
+++ b/system/smbus.c
@@ -136,7 +136,7 @@ static const struct pci_smbus_controller smbcontrollers[] = {
     // {0x10DE, 0x0446, nv_mcp_get_smb},  // nForce 520
     // {0x10DE, 0x0542, nv_mcp_get_smb},  // nForce 560
     // {0x10DE, 0x07D8, nv_mcp_get_smb},  // nForce 630i
-    // {0x10DE, 0x03EB, nv_mcp_get_smb},  // nForce 630a
+    {0x10DE, 0x03EB, nv_mcp_get_smb},  // nForce 630a
     // {0x10DE, 0x0752, nv_mcp_get_smb},  // nForce 720a
     // {0x10DE, 0x0AA2, nv_mcp_get_smb},  // nForce 730i
     // {0x10DE, 0x0368, nv_mcp_get_smb},  // nForce 790i Ultra


### PR DESCRIPTION
![P1100828](https://user-images.githubusercontent.com/8375/170131878-5c4e35f0-9425-4364-913d-512c0e544fee.JPG)

The computer has survived several seconds of memtest86+ and a reboot :)

Off-topic, but since it shows on the picture: sharp-eyed readers might notice the ~2200 MHz CPU frequency. This isn't a bug in memtest86+: I'm still searching for the maximum frequency for stable operation (as in, absence of thermal shutdown at 100% CPU...), which is much lower when the case is closed. I wiped the old thermal paste and cleaned up the surfaces with IPA, laid brand-new MX-4 thermal paste - enough to spread over the whole surface of the processor's cover, not way too much to put thermal paste all over the sides of the socket - and both the CPU fan and system fan are forced at max speed > 3000 RPM. At thermal shutdown, the heatsink isn't too hot to touch with bare fingers.