### PR TITLE
Add Meteor Lake SMBus controller PCI device ID to the SMBus controller list.

### DIFF
--- a/system/smbus.c
+++ b/system/smbus.c
@@ -1232,6 +1232,7 @@ static const uint16_t intel_ich5_dids[] =
     0x51A3,  // Alder Lake-P (PCH)
     0x54A3,  // Alder Lake-M (PCH)
     0x7A23,  // Raptor Lake-S (PCH)
+    0x7E22,  // Meteor Lake (PCH)
 };
 
 static bool find_in_did_array(uint16_t did, const uint16_t * ids, unsigned int size)


### PR DESCRIPTION
Following a Phoronix news item about Intel adding Meteor Lake support to Coreboot, I went looking at the changes, and noticed a SMBus PCI device ID in there. Namely, PCI_DID_INTEL_MTL_SMBUS in https://github.com/coreboot/coreboot/blob/master/src/include/device/pci_ids.h . 1383f871d8b379a5051f004d3605f77297e9abb8 gave me the idea for this one-liner.
This PCI ID isn't part of the Linux driver yet, though: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/i2c/busses/i2c-i801.c . So it _might_ be a bit early to add this trivial commit in memtest86+, especially since it's going to be a while before Meteor Lake hits the market, and an apparent break to the "tradition" of a trailing 3 hex digit for the PCI device IDs of recent models' SMBus controllers is eyebrow-raising.