### PR TITLE
Add much bigger PASS/FAIL banner

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (C) 2020-2022 Martin Whitaker.
+// Copyright (C) 2004-2022 Sam Demeulemeester.
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -31,6 +32,17 @@
 // Constants
 //------------------------------------------------------------------------------
 
+#define POP_STAT_R       12
+#define POP_STAT_C       18
+
+#define POP_STAT_W       44
+#define POP_STAT_H       9
+
+#define POP_STAT_LAST_R  (POP_STAT_R + POP_STAT_H - 1)
+#define POP_STAT_LAST_C  (POP_STAT_C + POP_STAT_W - 1)
+
+#define POP_STATUS_REGION  POP_STAT_R, POP_STAT_C, POP_STAT_LAST_R, POP_STAT_LAST_C
+
 #define SPINNER_PERIOD  100     // milliseconds
 
 #define NUM_SPIN_STATES 4
@@ -60,6 +72,8 @@ static uint64_t next_spin_time = 0; // TSC time stamp
 static int prev_sec = -1;               // previous second
 static bool timed_update_done = false;  // update cycle status
 
+static uint16_t popup_status_save_buffer[POP_STAT_W * POP_STAT_H];
+
 //------------------------------------------------------------------------------
 // Variables
 //------------------------------------------------------------------------------
@@ -67,6 +81,8 @@ static bool timed_update_done = false;  // update cycle status
 int scroll_message_row;
 
 int max_cpu_temp = 0;
+
+bool big_status_displayed = false;
 
 display_mode_t display_mode = DISPLAY_MODE_NA;
 
@@ -324,9 +340,53 @@ void display_temperature(void)
     printf(1, 20-offset, "%2i/%2i%cC", actual_cpu_temp, max_cpu_temp, 0xF8);
 }
 
+void display_big_status(bool pass)
+{
+    save_screen_region(POP_STATUS_REGION, popup_status_save_buffer);
+
+    set_background_colour(BLACK);
+    set_foreground_colour(pass ? GREEN : RED);
+    clear_screen_region(POP_STATUS_REGION);
+
+    if (pass) {
+        prints(POP_STAT_R+1, POP_STAT_C+5, "######      ##      #####    #####  ");
+        prints(POP_STAT_R+2, POP_STAT_C+5, "##   ##    ####    ##   ##  ##   ## ");
+        prints(POP_STAT_R+3, POP_STAT_C+5, "##   ##   ##  ##   ##       ##      ");
+        prints(POP_STAT_R+4, POP_STAT_C+5, "######   ##    ##   #####    #####  ");
+        prints(POP_STAT_R+5, POP_STAT_C+5, "##       ########       ##       ## ");
+        prints(POP_STAT_R+6, POP_STAT_C+5, "##       ##    ##  ##   ##  ##   ## ");
+        prints(POP_STAT_R+7, POP_STAT_C+5, "##       ##    ##   #####    #####  ");
+    } else {
+        prints(POP_STAT_R+1, POP_STAT_C+5, "#######     ##      ######   ##     ");
+        prints(POP_STAT_R+2, POP_STAT_C+5, "##         ####       ##     ##     ");
+        prints(POP_STAT_R+3, POP_STAT_C+5, "##        ##  ##      ##     ##     ");
+        prints(POP_STAT_R+4, POP_STAT_C+5, "#####    ##    ##     ##     ##     ");
+        prints(POP_STAT_R+5, POP_STAT_C+5, "##       ########     ##     ##     ");
+        prints(POP_STAT_R+6, POP_STAT_C+5, "##       ##    ##     ##     ##     ");
+        prints(POP_STAT_R+7, POP_STAT_C+5, "##       ##    ##   ######   ###### ");
+    }
+    set_background_colour(BLUE);
+    set_foreground_colour(WHITE);
+    big_status_displayed = true;
+}
+
+void restore_big_status(void)
+{
+    restore_screen_region(POP_STATUS_REGION, popup_status_save_buffer);
+    big_status_displayed = false;
+}
+
 void check_input(void)
 {
-    switch (get_key()) {
+    char input_key = get_key();
+
+    if (input_key == '\0') {
+        return;
+    } else if (big_status_displayed) {
+        restore_big_status();
+    }
+
+    switch (input_key) {
       case ESC:
         clear_message_area();
         display_notice("Rebooting...");

--- a/app/display.c
+++ b/app/display.c
@@ -72,6 +72,7 @@ static uint64_t next_spin_time = 0; // TSC time stamp
 static int prev_sec = -1;               // previous second
 static bool timed_update_done = false;  // update cycle status
 
+bool big_status_displayed = false;
 static uint16_t popup_status_save_buffer[POP_STAT_W * POP_STAT_H];
 
 //------------------------------------------------------------------------------
@@ -81,8 +82,6 @@ static uint16_t popup_status_save_buffer[POP_STAT_W * POP_STAT_H];
 int scroll_message_row;
 
 int max_cpu_temp = 0;
-
-bool big_status_displayed = false;
 
 display_mode_t display_mode = DISPLAY_MODE_NA;
 
@@ -342,6 +341,10 @@ void display_temperature(void)
 
 void display_big_status(bool pass)
 {
+    if (big_status_displayed) {
+        return;
+    }
+
     save_screen_region(POP_STATUS_REGION, popup_status_save_buffer);
 
     set_background_colour(BLACK);

--- a/app/display.h
+++ b/app/display.h
@@ -194,10 +194,10 @@ typedef enum {
     printf(scroll_message_row, col, __VA_ARGS__)
 
 #define display_notice(str) \
-    prints(ROW_MESSAGE_T + 6, (SCREEN_WIDTH - strlen(str)) / 2, str)
+    prints(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - strlen(str)) / 2, str)
 
 #define display_notice_with_args(length, ...) \
-    printf(ROW_MESSAGE_T + 6, (SCREEN_WIDTH - length) / 2, __VA_ARGS__)
+    printf(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - length) / 2, __VA_ARGS__)
 
 #define clear_footer_message() \
     { \

--- a/app/display.h
+++ b/app/display.h
@@ -218,8 +218,6 @@ typedef enum {
 
 extern int scroll_message_row;
 
-extern bool big_status_displayed;
-
 extern display_mode_t display_mode;
 
 void display_init(void);

--- a/app/display.h
+++ b/app/display.h
@@ -218,6 +218,8 @@ typedef enum {
 
 extern int scroll_message_row;
 
+extern bool big_status_displayed;
+
 extern display_mode_t display_mode;
 
 void display_init(void);
@@ -233,6 +235,10 @@ void display_start_pass(void);
 void display_start_test(void);
 
 void display_temperature(void);
+
+void display_big_status(bool pass);
+
+void restore_big_status(void);
 
 void check_input(void);
 

--- a/app/error.c
+++ b/app/error.c
@@ -369,6 +369,10 @@ void error_update(void)
         display_error_count(error_count);
         display_status("Failed!");
 
+        if (error_count == 1) {
+            display_big_status(false);
+        }
+
         if (enable_tty) {
             tty_error_redraw();
         }

--- a/app/main.c
+++ b/app/main.c
@@ -4,8 +4,8 @@
 // Derived from memtest86+ main.c:
 //
 // MemTest86+ V5 Specific code (GPL V2.0)
-// By Samuel DEMEULEMEESTER, sdemeule@memtest.org
-// http://www.canardpc.com - http://www.memtest.org
+// By Samuel DEMEULEMEESTER, memtest@memtest.org
+// https://www.memtest.org
 // ------------------------------------------------
 // main.c - MemTest-86  Version 3.5
 //
@@ -629,9 +629,7 @@ void main(void)
             display_pass_count(pass_num);
             if (error_count == 0) {
                 display_status("Pass   ");
-                if (!big_status_displayed) {
-                    display_big_status(true);
-                }
+                display_big_status(true);
                 //display_notice("** Pass completed, no errors **");
             }
         }

--- a/app/main.c
+++ b/app/main.c
@@ -629,7 +629,10 @@ void main(void)
             display_pass_count(pass_num);
             if (error_count == 0) {
                 display_status("Pass   ");
-                display_notice("** Pass completed, no errors **");
+                if (!big_status_displayed) {
+                    display_big_status(true);
+                }
+                //display_notice("** Pass completed, no errors **");
             }
         }
     }


### PR DESCRIPTION
The goal is to see the actual test result (PASS or FAIL) far away. 

Pressing any key will remove the banner.