### PR TITLE
Usb improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ recognised:
     * where *type* is one of
       * legacy
       * usb
-      * buggy-usb
+  * usbdebug
+    * pauses after probing for USB keyboards
+  * usbinit=*mode*
+    * where *mode* is one of
+      * 1 = use the two-step init sequence for high speed devices
+      * 2 = add a second USB reset in the init sequence
+      * 3 = the combination of modes 1 and 2
   * console=ttyS*x*,*y*
     * activate serial/tty console output, where *x* is one of the following IO port
       *  0 = 0x3F8
@@ -152,9 +158,7 @@ recognised:
 Memtest86+ supports both the legacy keyboard interface (using I/O ports 0x60
 and 0x64) and USB keyboards (using its own USB device drivers). One or the
 other can be selected via the boot command line, If neither is selected, the
-default is to use both. An additional option on the boot command line is
-`buggy-usb` which enables the longer initialisation sequence required by some
-older USB devices.
+default is to use both.
 
 Older BIOSs usually support USB legacy keyboard emulation, which makes USB
 keyboards act like legacy keyboards connected to ports 0x60 and 0x64. This
@@ -169,6 +173,10 @@ emulation and add `keyboard=legacy` on the boot command line.
 **NOTE**: Some UEFI BIOSs only support USB legacy keyboard emulation when
 you enable the Compatibility System Module (CSM) in the BIOS setup. Others
 only support it when actually booting in legacy mode.
+
+Many USB devices don't fully conform to the USB specification. If the USB
+keyboard probe hangs or fails to detect your keyboard, try the various
+workarounds provided by the "usbinit" boot option.
 
 **NOTE**: Memtest86+'s USB device drivers are work in progress. Not all USB
 devices are supported yet, and there may be problems on some hardware.

--- a/app/config.c
+++ b/app/config.c
@@ -175,9 +175,6 @@ static void parse_option(const char *option, const char *params)
             keyboard_types = KT_LEGACY;
         } else if (strncmp(params, "usb", 4) == 0) {
             keyboard_types = KT_USB;
-        } else if (strncmp(params, "buggy-usb", 10) == 0) {
-            keyboard_types = KT_USB;
-            usb_init_options |= USB_EXTRA_RESET;
         }
     } else if (strncmp(option, "powersave", 10) == 0) {
         if (strncmp(params, "off", 4) == 0) {
@@ -201,6 +198,14 @@ static void parse_option(const char *option, const char *params)
         enable_trace = true;
     } else if (strncmp(option, "usbdebug", 9) == 0) {
         usb_init_options |= USB_DEBUG;
+    } else if (strncmp(option, "usbinit", 8) == 0) {
+        if (strncmp(params, "1", 2) == 0) {
+            usb_init_options |= USB_2_STEP_INIT;
+        } else if (strncmp(params, "2", 2) == 0) {
+            usb_init_options |= USB_EXTRA_RESET;
+        } else if (strncmp(params, "3", 2) == 0) {
+            usb_init_options |= USB_2_STEP_INIT|USB_EXTRA_RESET;
+        }
     } else if (strncmp(option, "nosm", 5) == 0) {
         enable_sm = false;
     }

--- a/app/main.c
+++ b/app/main.c
@@ -22,6 +22,7 @@
 #include "cache.h"
 #include "cpuid.h"
 #include "cpuinfo.h"
+#include "heap.h"
 #include "hwctrl.h"
 #include "hwquirks.h"
 #include "io.h"
@@ -215,6 +216,8 @@ static void global_init(void)
     cpuinfo_init();
 
     pmem_init();
+
+    heap_init();
 
     pci_init();
 

--- a/build32/Makefile
+++ b/build32/Makefile
@@ -20,6 +20,7 @@ SYS_OBJS = system/acpi.o \
            system/cpulocal.o \
            system/ehci.o \
            system/font.o \
+           system/heap.o \
            system/hwctrl.o \
            system/hwquirks.o \
            system/keyboard.o \

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -21,6 +21,7 @@ SYS_OBJS = system/acpi.o \
            system/ehci.o \
            system/font.o \
            system/hwctrl.o \
+           system/heap.o \
            system/hwquirks.o \
            system/keyboard.o \
            system/ohci.o \

--- a/system/heap.c
+++ b/system/heap.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2022 Martin Whitaker.
+
+#include <stdint.h>
+
+#include "boot.h"
+
+#include "memsize.h"
+#include "pmem.h"
+
+#include "heap.h"
+
+//------------------------------------------------------------------------------
+// Types
+//------------------------------------------------------------------------------
+
+typedef struct {
+    int         segment;
+    uintptr_t   start;
+    uintptr_t   end;
+} heap_t;
+
+//------------------------------------------------------------------------------
+// Private Variables
+//------------------------------------------------------------------------------
+
+static heap_t lm_heap = { .segment = -1, .start = 0, .end = 0 };
+static heap_t hm_heap = { .segment = -1, .start = 0, .end = 0 };
+
+//------------------------------------------------------------------------------
+// Private Functions
+//------------------------------------------------------------------------------
+
+static size_t num_pages(size_t size)
+{
+    return (size + PAGE_SIZE - 1) >> PAGE_SHIFT;
+}
+
+static uintptr_t heap_alloc(const heap_t *heap, size_t size, uintptr_t alignment)
+{
+    if (heap->segment < 0) {
+        return 0;
+    }
+    uintptr_t addr = pm_map[heap->segment].end - num_pages(size);
+    addr &= ~((alignment - 1) >> PAGE_SHIFT);
+    if (addr < heap->start) {
+        return 0;
+    }
+    pm_map[heap->segment].end = addr;
+    return addr << PAGE_SHIFT;
+}
+
+static uintptr_t heap_mark(const heap_t *heap)
+{
+    if (heap->segment < 0) {
+        return 0;
+    }
+    return pm_map[heap->segment].end;
+}
+
+static void heap_rewind(const heap_t *heap, uintptr_t mark)
+{
+    if (heap->segment >= 0 && mark > pm_map[heap->segment].end && mark <= heap->end) {
+        pm_map[heap->segment].end = mark;
+    }
+}
+//------------------------------------------------------------------------------
+// Public Functions
+//------------------------------------------------------------------------------
+
+void heap_init(void)
+{
+    // Use the largest 20-bit addressable physical memory segment for the low-memory heap.
+    // Use the largest 32-bit addressable physical memory segment for the high-memory heap.
+    // Exclude memory occupied by the program or below it in that segment.
+    uintptr_t program_start = (uintptr_t)_start >> PAGE_SHIFT;
+    uintptr_t program_end   = program_start + num_pages(_end - _start);
+    uintptr_t max_segment_size = 0;
+    for (int i = 0; i < pm_map_size && pm_map[i].end <= PAGE_C(4,GB); i++) {
+        uintptr_t try_heap_start = pm_map[i].start;
+        uintptr_t try_heap_end   = pm_map[i].end;
+        if (program_start >= try_heap_start && program_end <= try_heap_end) {
+            try_heap_start = program_end;
+        }
+        uintptr_t segment_size = try_heap_end - try_heap_start;
+        if (segment_size >= max_segment_size) {
+            max_segment_size = segment_size;
+            if (try_heap_end <= PAGE_C(1,MB)) {
+                lm_heap.segment = i;
+                lm_heap.start   = try_heap_start;
+                lm_heap.end     = try_heap_end;
+            }
+            hm_heap.segment = i;
+            hm_heap.start   = try_heap_start;
+            hm_heap.end     = try_heap_end;
+        }
+    }
+}
+
+uintptr_t lm_heap_alloc(size_t size, uintptr_t alignment)
+{
+    return heap_alloc(&lm_heap, size, alignment);
+}
+
+uintptr_t lm_heap_mark(void)
+{
+    return heap_mark(&lm_heap);
+}
+
+void lm_heap_rewind(uintptr_t mark)
+{
+    heap_rewind(&lm_heap, mark);
+}
+
+uintptr_t hm_heap_alloc(size_t size, uintptr_t alignment)
+{
+    return heap_alloc(&hm_heap, size, alignment);
+}
+
+uintptr_t hm_heap_mark(void)
+{
+    return heap_mark(&hm_heap);
+}
+
+void hm_heap_rewind(uintptr_t mark)
+{
+    heap_rewind(&hm_heap, mark);
+}

--- a/system/heap.h
+++ b/system/heap.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef HEAP_H
+#define HEAP_H
+/**
+ * \file
+ *
+ * Provides functions to allocate and free chunks of physical memory that will
+ * be excluded from the memory tests. Two separate heaps are supported, one in
+ * low (20-bit addressable) memory, the other in high (32-bit addressable)
+ * memory.
+ *
+ *//*
+ * Copyright (C) 2022 Martin Whitaker.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Initialises the heaps.
+ */
+void heap_init(void);
+
+/**
+ * Allocates a chunk of physical memory below 1MB. The allocated region will
+ * be at least the requested size with the requested alignment. This memory
+ * is always mapped to the identical address in virtual memory.
+ *
+ * \param size              - the requested size in bytes.
+ * \param alignment         - the requested byte alignment (must be a power of 2).
+ *
+ * \returns
+ * On success, the allocated address in physical memory. On failure, 0.
+ */
+uintptr_t lm_heap_alloc(size_t size, uintptr_t alignment);
+
+/**
+ * Returns a value indicating the current allocation state of the low-memory
+ * heap. This value may be passed to lm_heap_rewind() to free any low memory
+ * allocated after this call.
+ *
+ * \returns
+ * An opaque value indicating the current allocation state.
+ */
+uintptr_t lm_heap_mark(void);
+
+/**
+ * Frees any low memory allocated since the specified mark was obtained from
+ * a call to lm_heap_mark().
+ *
+ * \param mark              - the mark that indicates how much memory to free.
+ */
+void lm_heap_rewind(uintptr_t mark);
+
+/**
+ * Allocates a chunk of physical memory below 4GB. The allocated region will
+ * be at least the requested size with the requested alignment. The caller is
+ * responsible for mapping it into virtual memory if required.
+ *
+ * \param size              - the requested size in bytes.
+ * \param alignment         - the requested byte alignment (must be a power of 2).
+ *
+ * \returns
+ * On success, the allocated address in physical memory. On failure, 0.
+ */
+uintptr_t hm_heap_alloc(size_t size, uintptr_t alignment);
+
+/**
+ * Returns a value indicating the current allocation state of the high-memory
+ * heap. This value may be passed to hm_heap_rewind() to free any high memory
+ * allocated after this call.
+ *
+ * \returns
+ * An opaque value indicating the current allocation state.
+ */
+uintptr_t hm_heap_mark(void);
+
+/**
+ * Frees any high memory allocated since the specified mark was obtained from
+ * a call to hm_heap_mark().
+ *
+ * \param mark              - the mark that indicates how much memory to free.
+ */
+void hm_heap_rewind(uintptr_t mark);
+
+#endif // HEAP_H

--- a/system/smp.c
+++ b/system/smp.c
@@ -20,10 +20,10 @@
 #include "efi.h"
 
 #include "cpuid.h"
+#include "heap.h"
 #include "memrw32.h"
 #include "memsize.h"
 #include "msr.h"
-#include "pmem.h"
 #include "string.h"
 #include "unistd.h"
 #include "vmem.h"
@@ -548,9 +548,9 @@ void smp_init(bool smp_enable)
         apic_id_to_cpu_num[cpu_num_to_apic_id[i]] = i;
     }
 
-    // Reserve last page of first segment for AP trampoline and sync objects.
+    // Allocate a page of low memory for AP trampoline and sync objects.
     // These need to remain pinned in place during relocation.
-    smp_heap_page = --pm_map[0].end;
+    smp_heap_page = lm_heap_alloc(PAGE_SIZE, PAGE_SIZE) >> PAGE_SHIFT;
 
     ap_startup_addr = (uintptr_t)startup;
 

--- a/system/usbhcd.c
+++ b/system/usbhcd.c
@@ -543,12 +543,12 @@ bool assign_usb_address(const usb_hcd_t *hcd, const usb_hub_t *hub, int port_num
     ep0->max_packet_size = default_max_packet_size(device_speed);
     ep0->interval        = 0;
 
-    // The device should currently be in Default state. For loww and full speed devices, We first fetch the first
+    // The device should currently be in Default state. For low and full speed devices, we first fetch the first
     // 8 bytes of the device descriptor to discover the maximum packet size for the control endpoint. We then set
     // the device address, which moves the device into Address state, and fetch the full device descriptor.
 
     size_t fetch_length = sizeof(usb_device_desc_t);
-    if (device_speed < USB_SPEED_HIGH) {
+    if (device_speed < USB_SPEED_HIGH || usb_init_options & USB_2_STEP_INIT) {
         fetch_length = 8;
         goto fetch_descriptor;
     }

--- a/system/usbhcd.h
+++ b/system/usbhcd.h
@@ -121,7 +121,8 @@ typedef enum {
     USB_DEFAULT_INIT    = 0,
     USB_EXTRA_RESET     = 1 << 0,
     USB_IGNORE_EHCI     = 1 << 1,
-    USB_DEBUG           = 1 << 2
+    USB_2_STEP_INIT     = 1 << 2,
+    USB_DEBUG           = 1 << 3
 } usb_init_options_t;
 
 /**


### PR DESCRIPTION
A couple of improvements to the USB drivers:

1. Make the memory allocation for the driver and hardware private data more robust (check that there's space available).
2. Replace the `keyboard=buggy-usb` option with a new `usbinit` option to support more workarounds.

I've tested this on my machines, but more testing would be welcome.