### PR TITLE
Better 80486 support

### DIFF
--- a/lib/unistd.c
+++ b/lib/unistd.c
@@ -22,8 +22,8 @@ void usleep(unsigned int usec)
             __builtin_ia32_pause();
         } while ((get_tsc() - t0) < cycles);
     } else {
-        // This will be highly inaccurate, but should give at least the requested delay.
-        volatile uint64_t count = (uint64_t)usec * 1000;
+        // This will be inaccurate, but should be close enough to the requested delay.
+        volatile uint64_t count = (uint64_t)usec * loops_per_usec;
         while (count > 0) {
             count--;
         }

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -55,6 +55,7 @@ uint32_t    ram_speed = 0;
 bool        no_temperature = false;
 
 uint32_t    clks_per_msec = 0;
+uint32_t    loops_per_usec = 0;
 
 //------------------------------------------------------------------------------
 // Private Functions

--- a/system/cpuinfo.h
+++ b/system/cpuinfo.h
@@ -118,6 +118,11 @@ extern bool no_temperature;
 extern uint32_t clks_per_msec;
 
 /**
+ * Number of loops required for 1us delay. Not very accurate but close enough.
+ */
+extern uint32_t loops_per_usec;
+
+/**
  * Determines the CPU info and stores it in the exported variables.
  */
 void cpuinfo_init(void);


### PR DESCRIPTION
This set of patches improves 80486 support:
 - Use -march=i486 in build32/Makefile CFLAGS to ensure the CPU remains supported in the 32 bit build.
 - Add BIOS reboot function, which is needed on some 80486 systems.
 - Provide busy loop calibration to use a better value than hardcoded 1000.

This fixes the "slowness" and reboot problem mentioned in https://github.com/memtest86plus/memtest86plus/discussions/20#discussioncomment-3018946