### PR TITLE
Heap manager optimization

### DIFF
--- a/system/ehci.c
+++ b/system/ehci.c
@@ -515,11 +515,11 @@ bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd)
     if (!reset_host_controller(op_regs)) return false;
 
     // Record the heap state to allow us to free memory.
-    uintptr_t initial_heap_mark = lm_heap_mark();
+    uintptr_t initial_heap_mark = heap_mark(HEAP_TYPE_LM_1);
 
     // Allocate and initialise a periodic frame list. This needs to be aligned on a 4K page boundary. Some controllers
     // don't support a programmable list length, so we just use the default length.
-    uintptr_t pfl_addr = lm_heap_alloc(EHCI_MAX_PFL_LENGTH * sizeof(uint32_t), PAGE_SIZE);
+    uintptr_t pfl_addr = heap_alloc(HEAP_TYPE_LM_1, EHCI_MAX_PFL_LENGTH * sizeof(uint32_t), PAGE_SIZE);
     if (pfl_addr == 0) {
         goto no_keyboards_found;
     }
@@ -530,7 +530,7 @@ bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd)
     }
 
     // Allocate and initialise a workspace for this controller. This needs to be permanently mapped into virtual memory.
-    uintptr_t workspace_addr = lm_heap_alloc(sizeof(workspace_t), PAGE_SIZE);
+    uintptr_t workspace_addr = heap_alloc(HEAP_TYPE_LM_1, sizeof(workspace_t), PAGE_SIZE);
     if (workspace_addr == 0) {
         goto no_keyboards_found;
     }
@@ -684,6 +684,6 @@ bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd)
     return true;
 
 no_keyboards_found:
-    lm_heap_rewind(initial_heap_mark);
+    heap_rewind(HEAP_TYPE_LM_1, initial_heap_mark);
     return false;
 }

--- a/system/heap.h
+++ b/system/heap.h
@@ -16,71 +16,48 @@
 #include <stddef.h>
 #include <stdint.h>
 
+typedef enum {
+    HEAP_TYPE_LM_1,
+    HEAP_TYPE_HM_1,
+    HEAP_TYPE_LAST
+} heap_type_t;
+
 /**
  * Initialises the heaps.
  */
 void heap_init(void);
 
 /**
- * Allocates a chunk of physical memory below 1MB. The allocated region will
- * be at least the requested size with the requested alignment. This memory
- * is always mapped to the identical address in virtual memory.
+ * Allocates a chunk of physical memory in the given heap. The allocated
+ * region will be at least the requested size with the requested alignment.
+ * This memory is always mapped to the identical address in virtual memory.
  *
- * \param size              - the requested size in bytes.
- * \param alignment         - the requested byte alignment (must be a power of 2).
- *
- * \returns
- * On success, the allocated address in physical memory. On failure, 0.
- */
-uintptr_t lm_heap_alloc(size_t size, uintptr_t alignment);
-
-/**
- * Returns a value indicating the current allocation state of the low-memory
- * heap. This value may be passed to lm_heap_rewind() to free any low memory
- * allocated after this call.
- *
- * \returns
- * An opaque value indicating the current allocation state.
- */
-uintptr_t lm_heap_mark(void);
-
-/**
- * Frees any low memory allocated since the specified mark was obtained from
- * a call to lm_heap_mark().
- *
- * \param mark              - the mark that indicates how much memory to free.
- */
-void lm_heap_rewind(uintptr_t mark);
-
-/**
- * Allocates a chunk of physical memory below 4GB. The allocated region will
- * be at least the requested size with the requested alignment. The caller is
- * responsible for mapping it into virtual memory if required.
- *
- * \param size              - the requested size in bytes.
- * \param alignment         - the requested byte alignment (must be a power of 2).
+ * \param size         - the requested size in bytes.
+ * \param alignment    - the requested byte alignment (must be a power of 2).
+ * \param heap         - the heap on which this allocation shall be performed.
  *
  * \returns
  * On success, the allocated address in physical memory. On failure, 0.
  */
-uintptr_t hm_heap_alloc(size_t size, uintptr_t alignment);
+uintptr_t heap_alloc(heap_type_t heap_id, size_t size, uintptr_t alignment);
 
 /**
- * Returns a value indicating the current allocation state of the high-memory
- * heap. This value may be passed to hm_heap_rewind() to free any high memory
- * allocated after this call.
+ * Returns a value indicating the current allocation state of the given
+ * memory heap. This value may be passed to heap_rewind() to free any
+ * memory from that heap allocated after this call.
  *
  * \returns
  * An opaque value indicating the current allocation state.
  */
-uintptr_t hm_heap_mark(void);
+uintptr_t heap_mark(heap_type_t heap_id);
 
 /**
- * Frees any high memory allocated since the specified mark was obtained from
- * a call to hm_heap_mark().
+ * Frees any memory allocated in the given heap since the specified mark was
+ * obtained from a call to heap_mark().
  *
- * \param mark              - the mark that indicates how much memory to free.
+ * \param mark         - the mark that indicates how much memory to free.
+ * \param heap         - the heap on which this rewind shall be performed.
  */
-void hm_heap_rewind(uintptr_t mark);
+void heap_rewind(heap_type_t heap_id, uintptr_t mark);
 
 #endif // HEAP_H

--- a/system/ohci.c
+++ b/system/ohci.c
@@ -457,10 +457,10 @@ bool ohci_init(uintptr_t base_addr, usb_hcd_t *hcd)
     }
 
     // Record the heap state to allow us to free memory.
-    uintptr_t initial_heap_mark = lm_heap_mark();
+    uintptr_t initial_heap_mark = heap_mark(HEAP_TYPE_LM_1);
 
     // Allocate and initialise a workspace for this controller. This needs to be permanently mapped into virtual memory.
-    uintptr_t workspace_addr = lm_heap_alloc(sizeof(workspace_t), PAGE_SIZE);
+    uintptr_t workspace_addr = heap_alloc(HEAP_TYPE_LM_1, sizeof(workspace_t), PAGE_SIZE);
     if (workspace_addr == 0) {
         goto no_keyboards_found;
     }
@@ -608,6 +608,6 @@ bool ohci_init(uintptr_t base_addr, usb_hcd_t *hcd)
     return true;
 
 no_keyboards_found:
-    lm_heap_rewind(initial_heap_mark);
+    heap_rewind(HEAP_TYPE_LM_1, initial_heap_mark);
     return false;
 }

--- a/system/smp.c
+++ b/system/smp.c
@@ -550,7 +550,7 @@ void smp_init(bool smp_enable)
 
     // Allocate a page of low memory for AP trampoline and sync objects.
     // These need to remain pinned in place during relocation.
-    smp_heap_page = lm_heap_alloc(PAGE_SIZE, PAGE_SIZE) >> PAGE_SHIFT;
+    smp_heap_page = heap_alloc(HEAP_TYPE_LM_1, PAGE_SIZE, PAGE_SIZE) >> PAGE_SHIFT;
 
     ap_startup_addr = (uintptr_t)startup;
 

--- a/system/uhci.c
+++ b/system/uhci.c
@@ -430,17 +430,17 @@ bool uhci_init(int bus, int dev, int func, uint16_t io_base, usb_hcd_t *hcd)
     if (!reset_host_controller(io_base)) return false;
 
     // Record the heap state to allow us to free memory.
-    uintptr_t initial_heap_mark = lm_heap_mark();
+    uintptr_t initial_heap_mark = heap_mark(HEAP_TYPE_LM_1);
 
     // Allocate the frame list. This needs to be aligned on a 4K page boundary.
-    uintptr_t fl_addr = lm_heap_alloc(UHCI_FL_LENGTH * sizeof(uint32_t), PAGE_SIZE);
+    uintptr_t fl_addr = heap_alloc(HEAP_TYPE_LM_1, UHCI_FL_LENGTH * sizeof(uint32_t), PAGE_SIZE);
     if (fl_addr == 0) {
         goto no_keyboards_found;
     }
     uint32_t *fl = (uint32_t *)fl_addr;
 
     // Allocate and initialise a workspace for this controller. This needs to be permanently mapped into virtual memory.
-    uintptr_t workspace_addr = lm_heap_alloc(sizeof(workspace_t), PAGE_SIZE);
+    uintptr_t workspace_addr = heap_alloc(HEAP_TYPE_LM_1, sizeof(workspace_t), PAGE_SIZE);
     if (workspace_addr == 0) {
         goto no_keyboards_found;
     }
@@ -574,6 +574,6 @@ bool uhci_init(int bus, int dev, int func, uint16_t io_base, usb_hcd_t *hcd)
     return true;
 
 no_keyboards_found:
-    lm_heap_rewind(initial_heap_mark);
+    heap_rewind(HEAP_TYPE_LM_1, initial_heap_mark);
     return false;
 }


### PR DESCRIPTION
This makes the code more flexible and the binary smaller, ~15% of the relative size increase of #116 (on x86_64).
As discussed in #116 , I'm not strongly attached to the "_1" suffixes, it was just a matter of reducing future diffs; adding more descriptive names is a valid alternative.