### PR TITLE
Add several PCI vendor and device IDs for SMBus controllers; minor refactor

### DIFF
--- a/system/hwquirks.c
+++ b/system/hwquirks.c
@@ -79,9 +79,9 @@ void quirks_init(void)
     //  -------------------------
     //  -- ALi Aladdin V Quirk --
     //  -------------------------
-    // As on many Socket 7 Motherboard, the L2 cache is external and must
+    // As on many Socket 7 Motherboards, the L2 cache is external and must
     // be detected by a proprietary way based on chipset registers
-    if (quirk.root_vid == 0x10B9 && quirk.root_did == 0x1541) {     // ALi Aladdin V (M1541)
+    if (quirk.root_vid == PCI_VID_ALI && quirk.root_did == 0x1541) {    // ALi Aladdin V (M1541)
         quirk.id    = QUIRK_ALI_ALADDIN_V;
         quirk.type |= QUIRK_TYPE_MEM_SIZE;
         quirk.process = get_m1541_l2_cache_size;
@@ -93,9 +93,9 @@ void quirks_init(void)
     // This motherboard has an ASB100 ASIC with a SMBUS Mux Integrated.
     // To access SPD later in the code, we need to configure the mux.
     // PS: Detection via DMI is unreliable, so using Root PCI Registers
-    if (quirk.root_vid == 0x8086 && quirk.root_did == 0x1130) {     // Intel i815
-        if (pci_config_read16(0, 0, 0, 0x2C) == 0x1043) {           // ASUS
-            if (pci_config_read16(0, 0, 0, 0x2E) == 0x8027) {       // TUSL2-C
+    if (quirk.root_vid == PCI_VID_INTEL && quirk.root_did == 0x1130) {  // Intel i815
+        if (pci_config_read16(0, 0, 0, 0x2C) == PCI_VID_ASUS) {         // ASUS
+            if (pci_config_read16(0, 0, 0, 0x2E) == 0x8027) {           // TUSL2-C
                 quirk.id    = QUIRK_TUSL2;
                 quirk.type |= QUIRK_TYPE_SMBUS;
                 quirk.process = asus_tusl2_configure_mux;

--- a/system/pci.h
+++ b/system/pci.h
@@ -12,6 +12,19 @@
 
 #include <stdint.h>
 
+/* Vendor IDs */
+#define PCI_VID_ATI          0x1002
+#define PCI_VID_AMD          0x1022
+#define PCI_VID_SIS          0x1039
+#define PCI_VID_ASUS         0x1043
+#define PCI_VID_EFAR         0x1055
+#define PCI_VID_ALI          0x10B9
+#define PCI_VID_NVIDIA       0x10DE
+#define PCI_VID_VIA          0x1106
+#define PCI_VID_SERVERWORKS  0x1166
+#define PCI_VID_HYGON        0x1D94
+#define PCI_VID_INTEL        0x8086
+
 #define PCI_MAX_BUS     256
 #define PCI_MAX_DEV     32
 #define PCI_MAX_FUNC    8

--- a/system/smbus.c
+++ b/system/smbus.c
@@ -1152,7 +1152,7 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
     smbus_id = (((uint32_t)vid) << 16) | did;
     switch(vid)
     {
-        case VID_INTEL:
+        case PCI_VID_INTEL:
         {
             if (find_in_did_array(did, intel_ich5_dids, sizeof(intel_ich5_dids) / sizeof(intel_ich5_dids[0]))) {
                 return ich5_get_smb();
@@ -1160,14 +1160,14 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
             if (did == 0x7113) { // 82371AB/EB/MB PIIX4
                 return piix4_get_smb();
             }
-            // 0x719B 82440/82443MX PMC ?
+            // 0x719B 82440/82443MX PMC - PIIX4
             // 0x0F13 ValleyView SMBus Controller ?
             // 0x8119 US15W ?
             return false;
         }
 
-        case VID_HYGON:
-        case VID_AMD:
+        case PCI_VID_HYGON:
+        case PCI_VID_AMD:
             switch(did)
             {
                 // case 0x740B: // AMD756
@@ -1184,7 +1184,7 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
             }
             break;
 
-        case VID_ATI:
+        case PCI_VID_ATI:
             switch(did)
             {
                 // case 0x4353: // SB200
@@ -1197,7 +1197,7 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
             }
             break;
 
-        case VID_NVIDIA:
+        case PCI_VID_NVIDIA:
             switch(did)
             {
                 // case 0x01B4: // nForce
@@ -1221,17 +1221,22 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
             }
             break;
 
-        case VID_SIS:
+        case PCI_VID_SIS:
             switch(did)
             {
-                case 0x0016: // SiS961/2/3
-                    // There are also SiS630 and SiS5595 SMBus controllers.
+                // case 0x0008:
+                    // SiS5595, SiS630 or other SMBus controllers - it's complicated.
+                // case 0x0016:
+                    // SiS961/2/3, known as "SiS96x" SMBus controllers.
+                // case 0x0018:
+                // case 0x0964:
+                    // SiS630 SMBus controllers.
                 default:
                     return false;
             }
             break;
 
-        case VID_VIA:
+        case PCI_VID_VIA:
             switch(did)
             {
                 // case 0x3040: // 82C586_3
@@ -1262,7 +1267,26 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
             }
             break;
 
-        case VID_SERVERWORKS:
+        case PCI_VID_EFAR:
+            switch(did)
+            {
+                // case 0x9463: // SLC90E66_3: PIIX4
+                default:
+                    return false;
+            }
+            break;
+
+        case PCI_VID_ALI:
+            switch(did)
+            {
+                // case 0x1563: // ali1563 (M1563) SMBus controller
+                // case 0x7101: // ali1535 (M1535) or ali15x3 (M1533/M1543) SMBus controllers
+                default:
+                    return false;
+            }
+            break;
+
+        case PCI_VID_SERVERWORKS:
             switch(did)
             {
                 case 0x0201: // CSB5
@@ -1417,7 +1441,7 @@ static bool nv_mcp_get_smb(void)
 static uint8_t get_spd(uint8_t slot_idx, uint16_t spd_adr)
 {
     switch ((smbus_id >> 16) & 0xFFFF) {
-      case VID_NVIDIA:
+      case PCI_VID_NVIDIA:
         return nf_read_spd_byte(slot_idx, (uint8_t)spd_adr);
       default:
         return ich5_read_spd_byte(slot_idx, spd_adr);

--- a/system/smbus.h
+++ b/system/smbus.h
@@ -10,16 +10,6 @@
  * Copyright (C) 2004-2022 Samuel Demeulemeester.
  */
 
-/* Vendor IDs */
-#define VID_ATI          0x1002
-#define VID_AMD          0x1022
-#define VID_SIS          0x1039
-#define VID_NVIDIA       0x10DE
-#define VID_VIA          0x1106
-#define VID_SERVERWORKS  0x1166
-#define VID_HYGON        0x1D94
-#define VID_INTEL        0x8086
-
 #define I2C_WRITE   0
 #define I2C_READ    1
 


### PR DESCRIPTION
This was inspired by #126 . It's a no-op on the binary code, at least with GCC 12: the useless cases are optimized away.

I moved the PCI VID defines to pci.h, so that they can be reused by e.g. hwquirks.c; maybe the defines' names should be prefixed by "PCI_" ?