### PR TITLE
Take ownership of all USB controllers before probing for devices.

### DIFF
--- a/system/ehci.c
+++ b/system/ehci.c
@@ -486,7 +486,7 @@ static const hcd_methods_t methods = {
 // Public Functions
 //------------------------------------------------------------------------------
 
-bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd)
+bool ehci_reset(int bus, int dev, int func, uintptr_t base_addr)
 {
     ehci_cap_regs_t *cap_regs = (ehci_cap_regs_t *)base_addr;
 
@@ -512,6 +512,15 @@ bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd)
     // Ensure the controller is halted and then reset it.
     if (!halt_host_controller(op_regs)) return false;
     if (!reset_host_controller(op_regs)) return false;
+
+    return true;
+}
+
+bool ehci_probe(uintptr_t base_addr, usb_hcd_t *hcd)
+{
+    ehci_cap_regs_t *cap_regs = (ehci_cap_regs_t *)base_addr;
+
+    ehci_op_regs_t *op_regs = (ehci_op_regs_t *)(base_addr + cap_regs->cap_length);
 
     // Record the heap state to allow us to free memory.
     uintptr_t initial_heap_mark = heap_mark(HEAP_TYPE_LM_1);

--- a/system/ehci.h
+++ b/system/ehci.h
@@ -15,12 +15,35 @@
 #include "usbhcd.h"
 
 /**
- * Initialises the EHCI device identified by bus, dev, func, and base_addr,
- * scans all the attached USB devices, and configures any HID USB keyboard
- * devices it finds to generate periodic interrupt transfers that report key
- * presses. Initialises hcd and returns true if the device was successfully
- * initialised and one or more keyboards were found.
+ * If necessary, takes ownership of the EHCI device at the specified base
+ * address, then resets it.
+ *
+ * \param bus       - the PCI bus number for accessing the device
+ * \param dev       - the PCI device number for accessing the device
+ * \param func      - the PCI function number for accessing the device
+ * \param base_addr - the base address of the device in virtual memory
+ *
+ * \returns
+ * true if ownership was acquired and the device was successfully reset,
+ * otherwise false.
  */
-bool ehci_init(int bus, int dev, int func, uintptr_t base_addr, usb_hcd_t *hcd);
+bool ehci_reset(int bus, int dev, int func, uintptr_t base_addr);
+
+/**
+ * Initialises the EHCI device at the specified base address, probes all
+ * the attached USB devices, and configures any HID USB keyboard devices
+ * it finds to generate periodic interrupt transfers that report key
+ * presses. If successful, initialises the specified host controller
+ * driver object accordingly.
+ *
+ * \param base_addr - the base address of the device in virtual memory
+ * \param hcd       - a pointer to a pre-allocated host controller
+ *                    driver object that can be used for this device
+ *
+ * \returns
+ * true if the device was successfully initialised and one or more
+ * keyboards were found, otherwise false.
+ */
+bool ehci_probe(uintptr_t base_addr, usb_hcd_t *hcd);
 
 #endif // EHCI_H

--- a/system/ohci.h
+++ b/system/ohci.h
@@ -15,12 +15,32 @@
 #include "usbhcd.h"
 
 /**
- * Initialises the OHCI device found at base_addr, scans all the attached USB
- * devices, and configures any HID USB keyboard devices it finds to generate
- * periodic interrupt transfers that report key presses. Initialises hcd and
- * returns true if the device was successfully initialised and one or more
- * keyboards were found.
+ * If necessary, takes ownership of the OHCI device at the specified base
+ * address, then resets it.
+ *
+ * \param base_addr - the base address of the device in virtual memory
+ *
+ * \returns
+ * true if ownership was acquired and the device was successfully reset,
+ * otherwise false.
  */
-bool ohci_init(uintptr_t base_addr, usb_hcd_t *hcd);
+bool ohci_reset(uintptr_t base_addr);
+
+/**
+ * Initialises the OHCI device at the specified base address, probes all
+ * the attached USB devices, and configures any HID USB keyboard devices
+ * it finds to generate periodic interrupt transfers that report key
+ * presses. If successful, initialises the specified host controller
+ * driver object accordingly.
+ *
+ * \param base_addr - the base address of the device in virtual memory
+ * \param hcd       - a pointer to a pre-allocated host controller
+ *                    driver object that can be used for this device
+ *
+ * \returns
+ * true if the device was successfully initialised and one or more
+ * keyboards were found, otherwise false.
+ */
+bool ohci_probe(uintptr_t base_addr, usb_hcd_t *hcd);
 
 #endif // OHCI_H

--- a/system/uhci.c
+++ b/system/uhci.c
@@ -420,7 +420,7 @@ static const hcd_methods_t methods = {
 // Public Functions
 //------------------------------------------------------------------------------
 
-bool uhci_init(int bus, int dev, int func, uint16_t io_base, usb_hcd_t *hcd)
+bool uhci_reset(int bus, int dev, int func, uint16_t io_base)
 {
     // Disable PCI and SMM interrupts.
     pci_config_write16(bus, dev, func, UHCI_LEGSUP, UHCI_LEGSUP_CLEAR);
@@ -429,6 +429,11 @@ bool uhci_init(int bus, int dev, int func, uint16_t io_base, usb_hcd_t *hcd)
     if (!halt_host_controller(io_base)) return false;
     if (!reset_host_controller(io_base)) return false;
 
+    return true;
+}
+
+bool uhci_probe(uint16_t io_base, usb_hcd_t *hcd)
+{
     // Record the heap state to allow us to free memory.
     uintptr_t initial_heap_mark = heap_mark(HEAP_TYPE_LM_1);
 

--- a/system/uhci.h
+++ b/system/uhci.h
@@ -15,13 +15,35 @@
 #include "usbhcd.h"
 
 /**
- * Initialises the UHCI device found at bus, dev, func on the PCI bus and
- * io_base in the I/O address space, scans all the attached USB devices, and
- * configures any HID USB keyboard devices it finds to generate periodic
- * interrupt transfers that report key presses. Initialises hcd and returns
- * true if the device was successfully initialised and one or more keyboards
- * were found.
+ * If necessary, takes ownership of the UHCI device at the specified base
+ * address, then resets it.
+ *
+ * \param bus       - the PCI bus number for accessing the device
+ * \param dev       - the PCI device number for accessing the device
+ * \param func      - the PCI function number for accessing the device
+ * \param io_base   - the base address of the device in I/O space
+ *
+ * \returns
+ * true if ownership was acquired and the device was successfully reset,
+ * otherwise false.
  */
-bool uhci_init(int bus, int dev, int func, uint16_t io_base, usb_hcd_t *hcd);
+bool uhci_reset(int bus, int dev, int func, uint16_t io_base);
+
+/**
+ * Initialises the UHCI device at the specified base address, probes all
+ * the attached USB devices, and configures any HID USB keyboard devices
+ * it finds to generate periodic interrupt transfers that report key
+ * presses. If successful, initialises the specified host controller
+ * driver object accordingly.
+ *
+ * \param io_base   - the base address of the device in I/O space
+ * \param hcd       - a pointer to a pre-allocated host controller
+ *                    driver object that can be used for this device
+ *
+ * \returns
+ * true if the device was successfully initialised and one or more
+ * keyboards were found, otherwise false.
+ */
+bool uhci_probe(uint16_t io_base, usb_hcd_t *hcd);
 
 #endif // UHCI_H

--- a/system/xhci.h
+++ b/system/xhci.h
@@ -15,12 +15,32 @@
 #include "usbhcd.h"
 
 /**
- * Initialises the XHCI device found at base_addr, scans all the attached USB
- * devices, and configures any HID USB keyboard devices it finds to generate
- * periodic interrupt transfers that report key presses. Initialises hcd and
- * returns true if the device was successfully initialised and one or more
- * keyboards were found.
+ * If necessary, takes ownership of the XHCI device at the specified base
+ * address, then resets it.
+ *
+ * \param base_addr - the base address of the device in virtual memory
+ *
+ * \returns
+ * true if ownership was acquired and the device was successfully reset,
+ * otherwise false.
  */
-bool xhci_init(uintptr_t base_addr, usb_hcd_t *hcd);
+bool xhci_reset(uintptr_t base_addr);
+
+/**
+ * Initialises the XHCI device at the specified base address, probes all
+ * the attached USB devices, and configures any HID USB keyboard devices
+ * it finds to generate periodic interrupt transfers that report key
+ * presses. If successful, initialises the specified host controller
+ * driver object accordingly.
+ *
+ * \param base_addr - the base address of the device in virtual memory
+ * \param hcd       - a pointer to a pre-allocated host controller
+ *                    driver object that can be used for this device
+ *
+ * \returns
+ * true if the device was successfully initialised and one or more
+ * keyboards were found, otherwise false.
+ */
+bool xhci_probe(uintptr_t base_addr, usb_hcd_t *hcd);
 
 #endif // XHCI_H


### PR DESCRIPTION
When two controllers are attached to a physical port (e.g. in the case of EHCI and its companion controllers, problems can occur if the BIOS still has control of one controller when we try to use the other one. So perform a first pass to scan the PCI bus and take ownership of and reset all the controllers we find, and perform a second pass to initialise the controllers and probe for attached devices.

As we don't support hot plugging, split the second pass into two, with the first probing the EHCI controllers and handing over any low and full speed devices to the companion controllers, and the second probing the remaining controller types.

This fixes a problem I found on my old AMD system, where connecting an external USB1 hub to an external USB2 hub caused the EHCI controller to detect the USB2 hub as a low speed device. It also brings us more into line with the way the Linux USB subsystem works.