### PR TITLE
Change how BadRAM patterns are aggregated to minimize the number of covered addresses

### DIFF
--- a/app/badram.c
+++ b/app/badram.c
@@ -106,6 +106,20 @@ static uintptr_t combi_cost(uintptr_t addr1, uintptr_t mask1, uintptr_t addr2, u
 }
 
 /*
+ * Determine if (addr1, mask1) is already covered by an existing pattern.
+ * Return true if that's the case, else false.
+ */
+static bool is_covered(uintptr_t addr1, uintptr_t mask1)
+{
+    for (int i = 0; i < num_patterns; i++) {
+        if (combi_cost(patterns[i].addr, patterns[i].mask, addr1, mask1) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
  * Find the cheapest array index to extend with the given addr/mask pair.
  * Return -1 if nothing below the given minimum cost can be found.
  */
@@ -173,7 +187,8 @@ bool badram_insert(uintptr_t addr)
 {
     uintptr_t mask = DEFAULT_MASK;
 
-    if (cheap_index(addr, DEFAULT_MASK, 1) != -1) {
+    // If covered by existing entry we return immediately
+    if (is_covered(addr, mask)) {
         return false;
     }
 

--- a/app/badram.c
+++ b/app/badram.c
@@ -128,7 +128,7 @@ static bool is_covered(pattern_t pattern)
 static int cheapest_pair()
 {
     // This is guaranteed to be overwritten with >= 0 as long as num_patterns > 1
-    int mergeidx = -1;
+    int merge_idx = -1;
 
     uintptr_t min_cost = UINTPTR_MAX;
     for (int i = 0; i < num_patterns - 1; i++) {
@@ -140,10 +140,10 @@ static int cheapest_pair()
         );
         if (tmp_cost <= min_cost) {
             min_cost = tmp_cost;
-            mergeidx = i;
+            merge_idx = i;
         }
     }
-    return mergeidx;
+    return merge_idx;
 }
 
 /*
@@ -202,15 +202,15 @@ static void insert_sorted(pattern_t pattern)
     pattern.addr &= pattern.mask;
 
     // Find index to insert entry into
-    int newidx = num_patterns;
+    int new_idx = num_patterns;
     for (int i = 0; i < num_patterns; i++) {
         if (pattern.addr < patterns[i].addr) {
-            newidx = i;
+            new_idx = i;
             break;
         }
     }
 
-    insert_at(pattern, newidx);
+    insert_at(pattern, new_idx);
 }
 
 //------------------------------------------------------------------------------
@@ -245,13 +245,13 @@ bool badram_insert(uintptr_t addr)
     // If we have more patterns than the max we need to force a merge
     if (num_patterns > MAX_PATTERNS) {
         // Find the pair that is the cheapest to merge
-        // mergeidx will be -1 if num_patterns < 2, but that means MAX_PATTERNS = 0 which is not a valid state anyway
-        int mergeidx = cheapest_pair();
+        // merge_idx will be -1 if num_patterns < 2, but that means MAX_PATTERNS = 0 which is not a valid state anyway
+        int merge_idx = cheapest_pair();
 
-        pattern_t combined = combined_pattern(mergeidx, mergeidx + 1);
+        pattern_t combined = combined_pattern(merge_idx, merge_idx + 1);
 
-        // Remove the source pair so that we can maintain order as combined does not necessarily belong in mergeidx
-        remove_pair(mergeidx);
+        // Remove the source pair so that we can maintain order as combined does not necessarily belong in merge_idx
+        remove_pair(merge_idx);
 
         insert_sorted(combined);
     }

--- a/app/badram.c
+++ b/app/badram.c
@@ -181,6 +181,11 @@ static void relocate_if_free(int idx)
 void badram_init(void)
 {
     num_patterns = 0;
+
+    for (int idx = 0; idx < MAX_PATTERNS; idx++) {
+        patterns[idx].addr = 0u;
+        patterns[idx].mask = 0u;
+    }
 }
 
 bool badram_insert(uintptr_t addr)

--- a/app/badram.c
+++ b/app/badram.c
@@ -171,19 +171,21 @@ void badram_init(void)
 
 bool badram_insert(uintptr_t addr)
 {
+    uintptr_t mask = DEFAULT_MASK;
+
     if (cheap_index(addr, DEFAULT_MASK, 1) != -1) {
         return false;
     }
 
     if (num_patterns < MAX_PATTERNS) {
         patterns[num_patterns].addr = addr;
-        patterns[num_patterns].mask = DEFAULT_MASK;
+        patterns[num_patterns].mask = mask;
         num_patterns++;
         relocate_if_free(num_patterns - 1);
     } else {
-        int idx = cheap_index(addr, DEFAULT_MASK, UINTPTR_MAX);
+        int idx = cheap_index(addr, mask, UINTPTR_MAX);
         uintptr_t caddr, cmask;
-        combine(patterns[idx].addr, patterns[idx].mask, addr, DEFAULT_MASK, &caddr, &cmask);
+        combine(patterns[idx].addr, patterns[idx].mask, addr, mask, &caddr, &cmask);
         patterns[idx].addr = caddr;
         patterns[idx].mask = cmask;
         relocate_if_free(idx);

--- a/app/badram.c
+++ b/app/badram.c
@@ -55,7 +55,7 @@ typedef struct {
 // Private Variables
 //------------------------------------------------------------------------------
 
-static pattern_t    pattern[MAX_PATTERNS];
+static pattern_t    patterns[MAX_PATTERNS];
 static int          num_patterns = 0;
 
 //------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ static int cheap_index(uintptr_t addr1, uintptr_t mask1, uintptr_t min_cost)
     int i = num_patterns;
     int idx = -1;
     while (i-- > 0) {
-        uintptr_t tmp_cost = combi_cost(pattern[i].addr, pattern[i].mask, addr1, mask1);
+        uintptr_t tmp_cost = combi_cost(patterns[i].addr, patterns[i].mask, addr1, mask1);
         if (tmp_cost < min_cost) {
             min_cost = tmp_cost;
             idx = i;
@@ -127,11 +127,11 @@ static int cheap_index(uintptr_t addr1, uintptr_t mask1, uintptr_t min_cost)
  */
 static int relocate_index(int idx)
 {
-    uintptr_t addr = pattern[idx].addr;
-    uintptr_t mask = pattern[idx].mask;
-    pattern[idx].addr = ~pattern[idx].addr;    // Never select idx
+    uintptr_t addr = patterns[idx].addr;
+    uintptr_t mask = patterns[idx].mask;
+    patterns[idx].addr = ~patterns[idx].addr;    // Never select idx
     int new = cheap_index(addr, mask, 1 + addresses(mask));
-    pattern[idx].addr = addr;
+    patterns[idx].addr = addr;
     return new;
 }
 
@@ -145,14 +145,14 @@ static void relocate_if_free(int idx)
     int newidx = relocate_index(idx);
     if (newidx >= 0) {
         uintptr_t caddr, cmask;
-        combine(pattern[newidx].addr, pattern[newidx].mask,
-                pattern[   idx].addr, pattern[   idx].mask,
+        combine(patterns[newidx].addr, patterns[newidx].mask,
+                patterns[   idx].addr, patterns[   idx].mask,
                 &caddr, &cmask);
-        pattern[newidx].addr = caddr;
-        pattern[newidx].mask = cmask;
+        patterns[newidx].addr = caddr;
+        patterns[newidx].mask = cmask;
         if (idx < --num_patterns) {
-            pattern[idx].addr = pattern[num_patterns].addr;
-            pattern[idx].mask = pattern[num_patterns].mask;
+            patterns[idx].addr = patterns[num_patterns].addr;
+            patterns[idx].mask = patterns[num_patterns].mask;
         }
         relocate_if_free (newidx);
     }
@@ -174,16 +174,16 @@ bool badram_insert(uintptr_t addr)
     }
 
     if (num_patterns < MAX_PATTERNS) {
-        pattern[num_patterns].addr = addr;
-        pattern[num_patterns].mask = DEFAULT_MASK;
+        patterns[num_patterns].addr = addr;
+        patterns[num_patterns].mask = DEFAULT_MASK;
         num_patterns++;
         relocate_if_free(num_patterns - 1);
     } else {
         int idx = cheap_index(addr, DEFAULT_MASK, UINTPTR_MAX);
         uintptr_t caddr, cmask;
-        combine(pattern[idx].addr, pattern[idx].mask, addr, DEFAULT_MASK, &caddr, &cmask);
-        pattern[idx].addr = caddr;
-        pattern[idx].mask = cmask;
+        combine(patterns[idx].addr, patterns[idx].mask, addr, DEFAULT_MASK, &caddr, &cmask);
+        patterns[idx].addr = caddr;
+        patterns[idx].mask = cmask;
         relocate_if_free(idx);
     }
     return true;
@@ -214,8 +214,8 @@ void badram_display(void)
             col = 7;
         }
         display_scrolled_message(col, "0x%0*x,0x%0*x",
-                                 TESTWORD_DIGITS, pattern[i].addr,
-                                 TESTWORD_DIGITS, pattern[i].mask);
+                                 TESTWORD_DIGITS, patterns[i].addr,
+                                 TESTWORD_DIGITS, patterns[i].mask);
         col += text_width;
     }
 }

--- a/app/badram.c
+++ b/app/badram.c
@@ -62,7 +62,9 @@ static int          num_patterns = 0;
 // Private Functions
 //------------------------------------------------------------------------------
 
-#define COMBINE_MASK(a,b,c,d) ((a & b & c & d) | (~a & b & ~c & d))
+// New mask is 1 where both masks were 1 (b & d) and the addresses were equal ~(a ^ c).
+// If addresses were unequal the new mask must be 0 to allow for both values.
+#define COMBINE_MASK(a,b,c,d) ((b & d) & ~(a ^ c))
 
 /*
  * Combine two addr/mask pairs to one addr/mask pair.


### PR DESCRIPTION
Hi,

First of all, thank you so much for this wonderful program. It has certainly been useful to me, and I'm sure, countless others! I also love that you've added functionality for generating BadRAM patterns, that is very useful to me (I seem to be cursed with faulty RAM as of late).

Regarding the BadRAM pattern generation: I have implemented some changes in how the algorithm aggregates the memory addresses so that it now generates addr/mask pairs that cover fewer addresses (while still covering all faulty addresses, of course).

I did not find any guidelines for how to contribute to your project, so please let me know if there is anything you would like me to change.

I've written a fairly detailed description in the commit message of 2ab6b313f71604189a1f2e4e1088131dc999d619, but allow me to paste it here:

### Explanation and motivation
Prior to this patch, a list of up to MAX_PATTERNS (=10) addr/mask tuples
(aka. pattern) were maintained, adding failing addresses one by one to
the list until it was full. When full, space was created by forcing a
merge of the new address with the existing pattern that would grow the
least (with regards to number of addresses covered by the pattern) by
merging it with the new address. This can lead to a great imbalance in
the number of addresses covered by the patterns. Consider the following:

MAX_PATTERNS=4 (for illustrative purposes).
The following addresses are faulted and added to patterns:
```
0x00, 0x10, 0x20, 0x68, 0xa0, 0xb0, 0xc0, 0xd0
```

This is the end result with the implementation prior to this commit:

```
patterns = [
  (0x00, 0xe8),
  (0x00, 0x18),
  (0x68, 0xf8),
  (0x90, 0x98)
]
```
Total addresses covered: 120.

This commit changes how the merges are done, not only considering a
merge between the new address and existing patterns, but also between
existing patterns. It keeps the patterns in ascending order (by .addr)
in patterns, and a new address is always inserted into patterns (even if
num_patterns == MAX_PATTERNS, patterns is of MAX_PATTERNS+1 size). Then,
if num_patterns > MAX_PATTERNS, we find the pair of patterns (only
considering neighbours, assuming for any pattern i, i-1 or i+1 will
be the best candidate for a merge) that would be the cheapest to
merge (using the same metric as prior to this patch), and merge those.

With this commit, this is the result of the exact same sequence of
addresses as above:
```
[
  (0x00, 0xe0),
  (0x68, 0xf8),
  (0xa0, 0xe8),
  (0xc0, 0xe8)
]
```
Total addresses covered: 72.

A drawback of the current implementation (as compared to the prior)
is that it does not make any attempt at merging patterns until
num_patterns == MAX_PATTERNS, which can lead to having several patterns
that could've been merged into one at no additional cost. I.e.:
```
patterns = [
  (0x00, 0xf8),
  (0x08, 0xf8)
]
```
can appear, even if
```
patterns = [
  (0x00, 0xf0)
]
```
represents the exact same addresses at the same cost.

### Real world example
Here are some real world examples from the same computer, listed in the order they were ran.

#### Without patch (1 pass)
```
0x0000000085488120 & 0xffffffffc56f8160 (262144 addresses, 0.25 MiB)
0x0000000097408100 & 0xfffffffff7f5c100 (65536 addresses, 0.06 MiB)
0x0000000097488000 & 0xffffffffffff8800 (16384 addresses, 0.02 MiB)
0x0000000097488400 & 0xffffffffffff8600 (8192 addresses, 0.01 MiB)
0x0000000097488830 & 0xffffffffffff8830 (4096 addresses, 0.00 MiB)
0x0000000097488e00 & 0xffffffffffff8e00 (4096 addresses, 0.00 MiB)
0x000000009748c000 & 0xffffffffffffc500 (4096 addresses, 0.00 MiB)
0x000000009f42c000 & 0xffffffffffffc100 (8192 addresses, 0.01 MiB)
0x00000000a0988020 & 0xffffffffe2be8020 (1048576 addresses, 1.00 MiB)
0x00000000a1d00000 & 0xffffffffe1d74100 (1048576 addresses, 1.00 MiB)
Total addresses: 2469888
```

#### With patch (5 passes)
```
0x0000000097408980 & 0xfffffffff7f5e9d8 (1024 addresses, 0.00 MiB)
0x0000000097488100 & 0xffffffffffffc100 (8192 addresses, 0.01 MiB)
0x000000009748c000 & 0xffffffffffffc100 (8192 addresses, 0.01 MiB)
0x000000009f42a100 & 0xffffffffffffe100 (4096 addresses, 0.00 MiB)
0x000000009f42c000 & 0xffffffffffffc100 (8192 addresses, 0.01 MiB)
0x00000000add88020 & 0xffffffffffff8020 (16384 addresses, 0.02 MiB)
0x00000000ae7ef838 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
0x00000000b0998020 & 0xffffffffffffa068 (2048 addresses, 0.00 MiB)
0x00000000b099bde8 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
0x00000000b3f038d0 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
Total addresses: 48152
```

#### Without patch (4 passes)
```
0x0000000085408200 & 0xfffffffffc5658240 (2097152 addresses, 2.00 MiB)
0x000000008540b080 & 0xfffffffffc565b280 (524288 addresses, 0.50 MiB)
0x0000000097408000 & 0xffffffffff7f58280 (65536 addresses, 0.06 MiB)
0x0000000097408040 & 0xffffffffff7f58050 (65536 addresses, 0.06 MiB)
0x0000000097408070 & 0xffffffffff7f58070 (32768 addresses, 0.03 MiB)
0x0000000097408100 & 0xffffffffff7f5c300 (32768 addresses, 0.03 MiB)
0x0000000097408200 & 0xffffffffff7f58228 (32768 addresses, 0.03 MiB)
0x000000009740a208 & 0xffffffffff7f5a208 (32768 addresses, 0.03 MiB)
0x000000009740b800 & 0xffffffffff7f5b820 (16384 addresses, 0.02 MiB)
0x000000009f428000 & 0xfffffffffffff8000 (32768 addresses, 0.03 MiB)
Total addresses: 2932736
```

#### With patch (7 passes)
```
0x0000000097488010 & 0xffffffffffffa650 (1024 addresses, 0.00 MiB)
0x0000000097488120 & 0xfffffffffffff120 (1024 addresses, 0.00 MiB)
0x00000000974891e0 & 0xffffffffffffd1e0 (512 addresses, 0.00 MiB)
0x000000009748a500 & 0xffffffffffffe580 (1024 addresses, 0.00 MiB)
0x000000009748c058 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
0x000000009748c060 & 0xffffffffffffc160 (2048 addresses, 0.00 MiB)
0x000000009748fe08 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
0x000000009f42a100 & 0xffffffffffffe100 (4096 addresses, 0.00 MiB)
0x000000009f42c890 & 0xffffffffffffc990 (1024 addresses, 0.00 MiB)
0x000000009f42f000 & 0xfffffffffffff340 (512 addresses, 0.00 MiB)
Total addresses: 11280
```

#### With patch (87 passes - yes, this ran for 199 hours)
```
0x00000000964e7358 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
0x0000000097408130 & 0xfffffffff7f5d9f8 (512 addresses, 0.00 MiB)
0x0000000097488100 & 0xffffffffffffc100 (8192 addresses, 0.01 MiB)
0x000000009748c008 & 0xffffffffffffc188 (2048 addresses, 0.00 MiB)
0x000000009748c060 & 0xffffffffffffd160 (1024 addresses, 0.00 MiB)
0x000000009748f000 & 0xfffffffffffff100 (2048 addresses, 0.00 MiB)
0x000000009f42a100 & 0xffffffffffffe100 (4096 addresses, 0.00 MiB)
0x000000009f42d800 & 0xfffffffffffff900 (1024 addresses, 0.00 MiB)
0x000000009f42e000 & 0xffffffffffffe100 (4096 addresses, 0.00 MiB)
0x00000000add8f9a0 & 0xfffffffffffffff8 (8 addresses, 0.00 MiB)
Total addresses: 23056
```

Note the dramatic reduction in the number of addresses covered by the patterns when using the patch. Also a bit curious how the test seems to not always find the same faulty addresses. Especially how the 87 passes failed to find the error at `0x00000000b3f038d0 & 0xfffffffffffffff8` which was found in 5 passes earlier.