### PR TITLE
move big status display overlay to top left corner to not hide fail details

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -32,10 +32,10 @@
 // Constants
 //------------------------------------------------------------------------------
 
-#define POP_STAT_R       12
-#define POP_STAT_C       18
+#define POP_STAT_R       2
+#define POP_STAT_C       0
 
-#define POP_STAT_W       44
+#define POP_STAT_W       33
 #define POP_STAT_H       9
 
 #define POP_STAT_LAST_R  (POP_STAT_R + POP_STAT_H - 1)
@@ -367,21 +367,21 @@ void display_big_status(bool pass)
     clear_screen_region(POP_STATUS_REGION);
 
     if (pass) {
-        prints(POP_STAT_R+1, POP_STAT_C+5, "######      ##      #####    #####  ");
-        prints(POP_STAT_R+2, POP_STAT_C+5, "##   ##    ####    ##   ##  ##   ## ");
-        prints(POP_STAT_R+3, POP_STAT_C+5, "##   ##   ##  ##   ##       ##      ");
-        prints(POP_STAT_R+4, POP_STAT_C+5, "######   ##    ##   #####    #####  ");
-        prints(POP_STAT_R+5, POP_STAT_C+5, "##       ########       ##       ## ");
-        prints(POP_STAT_R+6, POP_STAT_C+5, "##       ##    ##  ##   ##  ##   ## ");
-        prints(POP_STAT_R+7, POP_STAT_C+5, "##       ##    ##   #####    #####  ");
+        prints(POP_STAT_R+1, POP_STAT_C+2, "######    ##     ####   #### ");
+        prints(POP_STAT_R+2, POP_STAT_C+2, "##   ##  ####   ##  ## ##  ##");
+        prints(POP_STAT_R+3, POP_STAT_C+2, "##   ## ##  ##  ##     ##    ");
+        prints(POP_STAT_R+4, POP_STAT_C+2, "###### ##    ##  ####   #### ");
+        prints(POP_STAT_R+5, POP_STAT_C+2, "##     ########     ##     ##");
+        prints(POP_STAT_R+6, POP_STAT_C+2, "##     ##    ## ##  ## ##  ##");
+        prints(POP_STAT_R+7, POP_STAT_C+2, "##     ##    ##  ####   #### ");
     } else {
-        prints(POP_STAT_R+1, POP_STAT_C+5, "#######     ##      ######   ##     ");
-        prints(POP_STAT_R+2, POP_STAT_C+5, "##         ####       ##     ##     ");
-        prints(POP_STAT_R+3, POP_STAT_C+5, "##        ##  ##      ##     ##     ");
-        prints(POP_STAT_R+4, POP_STAT_C+5, "#####    ##    ##     ##     ##     ");
-        prints(POP_STAT_R+5, POP_STAT_C+5, "##       ########     ##     ##     ");
-        prints(POP_STAT_R+6, POP_STAT_C+5, "##       ##    ##     ##     ##     ");
-        prints(POP_STAT_R+7, POP_STAT_C+5, "##       ##    ##   ######   ###### ");
+        prints(POP_STAT_R+1, POP_STAT_C+2, "#######   ##    ###### ##    ");
+        prints(POP_STAT_R+2, POP_STAT_C+2, "##       ####     ##   ##    ");
+        prints(POP_STAT_R+3, POP_STAT_C+2, "##      ##  ##    ##   ##    ");
+        prints(POP_STAT_R+4, POP_STAT_C+2, "#####  ##    ##   ##   ##    ");
+        prints(POP_STAT_R+5, POP_STAT_C+2, "##     ########   ##   ##    ");
+        prints(POP_STAT_R+6, POP_STAT_C+2, "##     ##    ##   ##   ##    ");
+        prints(POP_STAT_R+7, POP_STAT_C+2, "##     ##    ## ###### ######");
     }
     set_background_colour(BLUE);
     set_foreground_colour(WHITE);


### PR DESCRIPTION
Without this patch the big black status display overlay ("FAIL") will hide the details, like addresses or patterns, of the failing tests.

Example without this patch:
![original-fail](https://user-images.githubusercontent.com/66070626/201094701-f23ff0c2-a805-487c-8a73-295179c0081f.jpg)

This patch makes the big status display a bit smaller and moves it to the top left of the screen where ususally static information like cpu cores, memory size and cache speeds are shown. This way the details about a failing test aren't hidden anymore.

With this patch applied it looks like this:
![patch-fail](https://user-images.githubusercontent.com/66070626/201094818-b3c705d6-d7df-4d7f-a321-d23afa77bbf2.jpg)

![patch-pass](https://user-images.githubusercontent.com/66070626/201094830-8a16a2a6-515e-44f9-957a-1c9ad5effcf0.jpg)
