### PR TITLE
make "FAIL"-banner removable by keypress

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -538,11 +538,6 @@ void do_tick(int my_cpu)
     // This only tick one time per second
     if (!timed_update_done) {
 
-        // Display FAIL banner if (new) errors detected
-        if (!big_status_displayed && error_count > 0) {
-            display_big_status(false);
-        }
-
         // Update temperature
         display_temperature();
 


### PR DESCRIPTION
The removed code, made the banner reappear every second. I completely removed the code, since the user already knows the test has failed, after removing the first banner.
