### PR TITLE
Improved own addr test

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,8 +481,9 @@ selected by the user.
 
 ### Test 2 : Address test, own address + window
 
-Across all memory regions, each address is written with its own address plus
-the window number and then each address is checked for consistency. This
+Across all memory regions, each address is written with its own virtual
+address plus the window number (for 32-bit images) or own physical address
+(for 64-bit images) and then each address is checked for consistency. This
 catches any errors in the high order address bits that would be missed when
 testing each window in turn. This test is performed sequentially with each
 available CPU, regardless of the CPU sequencing mode selected by the user.

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -51,7 +51,7 @@
 test_pattern_t test_list[NUM_TEST_PATTERNS] = {
     // ena,  cpu, stgs, itrs, errs, description
     { true,  SEQ,    1,    6,    0, "[Address test, walking ones, no cache] "},
-    { true,  SEQ,    1,    6,    0, "[Address test, own address in window]  "},
+    {false,  SEQ,    1,    6,    0, "[Address test, own address in window]  "},
     { true,  SEQ,    2,    6,    0, "[Address test, own address + window]   "},
     { true,  PAR,    1,    6,    0, "[Moving inversions, 1s & 0s]           "},
     { true,  PAR,    1,    3,    0, "[Moving inversions, 8 bit pattern]     "},


### PR DESCRIPTION
This modifies the own address + window test to use the physical address as the test pattern in 64-bit builds. This should make it easier to diagnose faults. Obviously we can't do this for 32-bit builds because the test word size isn't big enough to store a physical address.

This also disables test 1 by default, as discussed in issue #155. Test 2 should catch any faults caught by test 1.