### PR TITLE
Add a command line option to disable the big PASS/FAIL status display.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ recognised:
     * disables ACPI table parsing and the use of multiple CPU cores
   * nobench
     * disables the integrated memory benchmark
+  * nobigstatus
+    * disables the big PASS/FAIL pop-up status display
   * nosm
     * disables SMBUS/SPD parsing, DMI decoding and memory benchmark
   * nopause

--- a/app/config.c
+++ b/app/config.c
@@ -91,6 +91,7 @@ bool            exclude_ecores     = true;
 
 bool            smp_enabled        = true;
 
+bool            enable_big_status  = true;
 bool            enable_temperature = true;
 bool            enable_trace       = false;
 
@@ -194,6 +195,8 @@ static void parse_option(const char *option, const char *params)
         parse_serial_params(params);
     } else if (strncmp(option, "nobench", 8) == 0) {
         enable_bench = false;
+    } else if (strncmp(option, "nobigstatus", 12) == 0) {
+        enable_big_status = false;
     } else if (strncmp(option, "noehci", 7) == 0) {
         usb_init_options |= USB_IGNORE_EHCI;
     } else if (strncmp(option, "nopause", 8) == 0) {

--- a/app/config.h
+++ b/app/config.h
@@ -51,6 +51,7 @@ extern bool         exclude_ecores;
 
 extern bool         smp_enabled;
 
+extern bool         enable_big_status;
 extern bool         enable_temperature;
 extern bool         enable_trace;
 

--- a/app/display.c
+++ b/app/display.c
@@ -356,7 +356,7 @@ void display_temperature(void)
 
 void display_big_status(bool pass)
 {
-    if (big_status_displayed) {
+    if (!enable_big_status || big_status_displayed) {
         return;
     }
 


### PR DESCRIPTION
The big PASS/FAIL status provides no real benefit to users who only want to test their own personal machine and just gets in the way if errors are found. So provide a way to disable it.