### PR TITLE
Fix parallel build after the version number was moved to an external file

### DIFF
--- a/build32/Makefile
+++ b/build32/Makefile
@@ -81,7 +81,7 @@ boot/startup.o: ../boot/startup32.S ../boot/boot.h
 	@mkdir -p boot
 	$(CC) -m32 -x assembler-with-cpp -c -I../boot -o $@ $<
 
-boot/%.o: ../boot/%.S ../boot/boot.h
+boot/%.o: ../boot/%.S ../boot/boot.h app/build_version.h
 	@mkdir -p boot
 	$(CC) -m32 -x assembler-with-cpp -c -I../boot -Iapp -o $@ $<
 

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -80,7 +80,7 @@ boot/startup.o: ../boot/startup64.S ../boot/boot.h
 	@mkdir -p boot
 	$(CC) -x assembler-with-cpp -c -I../boot -o $@ $<
 
-boot/%.o: ../boot/%.S ../boot/boot.h
+boot/%.o: ../boot/%.S ../boot/boot.h app/build_version.h
 	@mkdir -p boot
 	$(CC) -x assembler-with-cpp -c -I../boot -Iapp -o $@ $<
 


### PR DESCRIPTION
Tonight, I tried to make a parallel build with my usual `cd build32; make clean; make -j; size memtest_shared; cd ..; cd build64; make clean; make -j; size memtest_shared; cd ..` recipe.
The build failed with:
```
gcc -m32 -x assembler-with-cpp -c -I../boot -Iapp -o boot/setup.o ../boot/setup.S
../boot/setup.S:21:10: fatal error: build_version.h: Aucun fichier ou dossier de ce type
   21 | #include "build_version.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:85 : boot/setup.o] Erreur 1
```
This PR fixes that :)