### PR TITLE
Allow use on headless EFI systems.

### DIFF
--- a/boot/bootparams.h
+++ b/boot/bootparams.h
@@ -58,6 +58,7 @@ typedef struct {
 
 #define VIDEO_TYPE_VLFB             0x23    // VESA VGA in graphic mode
 #define VIDEO_TYPE_EFI              0x70    // EFI graphic mode
+#define VIDEO_TYPE_NONE             0xff    // no video display (added for Memtest86+)
 
 #define LFB_CAPABILITY_64BIT_BASE   (1 << 1)
 

--- a/system/screen.c
+++ b/system/screen.c
@@ -42,7 +42,7 @@ static const rgb_value_t vga_pallete[16] = {
     { 255, 255, 255 }   // BOLD+WHITE
 };
 
-static vga_buffer_t *vga_buffer = (vga_buffer_t *)(0xb8000);
+static vga_buffer_t *vga_buffer = NULL;
 
 vga_buffer_t shadow_buffer;
 
@@ -64,7 +64,9 @@ static void vga_put_char(int row, int col, uint8_t ch, uint8_t attr)
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
-    (*vga_buffer)[row][col].value = shadow_buffer[row][col].value;
+    if (vga_buffer) {
+        (*vga_buffer)[row][col].value = shadow_buffer[row][col].value;
+    }
 }
 
 static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
@@ -239,6 +241,8 @@ void screen_init(void)
             uint32_t b = ((vga_pallete[i].b * b_max) / 255) << screen_info->blue_pos;
             lfb_pallete[i] = r | g | b;
         }
+    } else if (screen_info->orig_video_isVGA != VIDEO_TYPE_NONE) {
+        vga_buffer = (vga_buffer_t *)(0xb8000);
     }
 }
 


### PR DESCRIPTION
A headless EFI system may have no GOP devices. In this case, disable output to the physical display, but continue to write to the shadow buffer. This allows operation via a serial console.

This should satisfy #240, but I don't have a headless system to test it on.