### PR TITLE
Add a quirk to disable SMP on SuperMicro X10SDV

### DIFF
--- a/system/hwquirks.h
+++ b/system/hwquirks.h
@@ -23,7 +23,8 @@
 typedef enum {
     QUIRK_NONE,
     QUIRK_TUSL2,
-    QUIRK_ALI_ALADDIN_V
+    QUIRK_ALI_ALADDIN_V,
+    QUIRK_X10SDV_NOSMP
 } quirk_id_t;
 
 typedef struct {

--- a/system/pci.h
+++ b/system/pci.h
@@ -12,6 +12,11 @@
 
 #include <stdint.h>
 
+#define PCI_VID_REG          0x00
+#define PCI_DID_REG          0x02
+#define PCI_SUB_VID_REG      0x2C
+#define PCI_SUB_DID_REG      0x2E
+
 /* Vendor IDs */
 #define PCI_VID_ATI          0x1002
 #define PCI_VID_AMD          0x1022
@@ -22,6 +27,7 @@
 #define PCI_VID_NVIDIA       0x10DE
 #define PCI_VID_VIA          0x1106
 #define PCI_VID_SERVERWORKS  0x1166
+#define PCI_VID_SUPERMICRO   0x15D9
 #define PCI_VID_HYGON        0x1D94
 #define PCI_VID_INTEL        0x8086
 

--- a/system/smp.c
+++ b/system/smp.c
@@ -21,6 +21,7 @@
 
 #include "cpuid.h"
 #include "heap.h"
+#include "hwquirks.h"
 #include "memrw32.h"
 #include "memsize.h"
 #include "msr.h"
@@ -537,6 +538,12 @@ void smp_init(bool smp_enable)
             // We don't currently support x2APIC mode.
             smp_enable = false;
         }
+    }
+
+    // Process SMP Quirks
+    if (quirk.type & QUIRK_TYPE_SMP) {
+        // quirk.process();
+        smp_enable = false;
     }
 
     if (smp_enable) {


### PR DESCRIPTION
Until we find a proper solution, this patch will allow Memtest86+ to run with SMP disabled on Super Micro X10SDV Motherboards.