### PR TITLE
Support cache and temperature info for VIA/Centaur/Zhaoxin CPUs

### DIFF
--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -128,6 +128,26 @@ void cpuid_init(void)
             );
         }
         break;
+      case 'C':
+        if (cpuid_info.vendor_id.str[5] == 'I') break; // Cyrix
+        // VIA / CentaurHauls
+        if (cpuid_info.max_xcpuid >= 0x80000005) {
+            cpuid(0x80000005, 0,
+                &reg[0],
+                &reg[1],
+                &cpuid_info.cache_info.raw[0],
+                &cpuid_info.cache_info.raw[1]
+            );
+        }
+        if (cpuid_info.max_xcpuid >= 0x80000006) {
+            cpuid(0x80000006, 0,
+                &reg[0],
+                &reg[1],
+                &cpuid_info.cache_info.raw[2],
+                &cpuid_info.cache_info.raw[3]
+            );
+        }
+        break;
       case 'G':
         // Intel Processors
         // No cpuid info to read.

--- a/system/cpuid.h
+++ b/system/cpuid.h
@@ -122,7 +122,7 @@ typedef union {
 } cpuid_brand_string_t;
 
 typedef union {
-    uint32_t        raw[12];
+    uint32_t        raw[4];
     struct {
         uint32_t                : 24;
         uint32_t    l1_i_size   : 8;

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -71,10 +71,16 @@ static void determine_cache_size()
         l3_cache *= 512;
         break;
       case 'C':
-        // Zhaoxin CPU only
-        if (cpuid_info.version.family != 7) {
+        if (cpuid_info.vendor_id.str[5] == 'I') break; // Cyrix
+        // VIA C3/C7/Nano
+        if (cpuid_info.version.family == 6) {
+            l1_cache = cpuid_info.cache_info.l1_d_size;
+            l2_cache = cpuid_info.cache_info.l2_size;
+            break;
+        } else if (cpuid_info.version.family != 7) {
             break;
         }
+        // Zhaoxin CPU only
         /* fall through */
       case 'G':
         // Intel Processors

--- a/system/temperature.c
+++ b/system/temperature.c
@@ -70,16 +70,19 @@ int get_cpu_temperature(void)
     }
 
     // VIA/Centaur/Zhaoxin CPU
-    else if (cpuid_info.vendor_id.str[0] == 'C' && cpuid_info.vendor_id.str[1] == 'e' && (cpuid_info.version.family == 6 || cpuid_info.version.family == 7)) {
-        uint32_t msr_temp;
+    else if (cpuid_info.vendor_id.str[0] == 'C' && cpuid_info.vendor_id.str[1] == 'e'
+          && (cpuid_info.version.family == 6 || cpuid_info.version.family == 7)) {
+
+        uint32_t msrl, msrh, msr_temp;
+
         if (cpuid_info.version.family == 7 || cpuid_info.version.model == 0xF) {
             msr_temp = 0x1423;  // Zhaoxin, Nano
         } else if (cpuid_info.version.model == 0xA || cpuid_info.version.model == 0xD) {
             msr_temp = 0x1169;  // C7 A/D
-        } else
+        } else {
             return 0;
+        }
 
-        uint32_t msrl, msrh;
         rdmsr(msr_temp, msrl, msrh);
         return (int)(msrl & 0xffffff);
     }


### PR DESCRIPTION
Use extended CPUID for VIA C3/C7/Nano cache information.

Use MSR reads for Nano/Zhaoxin and VIA C7 processor temperature.

Tested on VIA C7-D 1.5GHz.