### PR TITLE
[cpuinfo] Fix old CPUs (P5/P6-class) name and cache info

### DIFF
--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -24,6 +24,8 @@ void cpuid_init(void)
     uint32_t reg[4];
     char *p, *q;
 
+    return;
+
     // Get the max standard cpuid & vendor ID.
     cpuid(0x0, 0,
         &cpuid_info.max_cpuid,

--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -24,8 +24,6 @@ void cpuid_init(void)
     uint32_t reg[4];
     char *p, *q;
 
-    return;
-
     // Get the max standard cpuid & vendor ID.
     cpuid(0x0, 0,
         &cpuid_info.max_cpuid,

--- a/system/cpuid.c
+++ b/system/cpuid.c
@@ -108,50 +108,21 @@ void cpuid_init(void)
     }
 
     // Get cache information.
-    switch (cpuid_info.vendor_id.str[0]) {
-      case 'A':
-        // AMD Processors
-        if (cpuid_info.max_xcpuid >= 0x80000005) {
-            cpuid(0x80000005, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[0],
-                &cpuid_info.cache_info.raw[1]
-            );
-        }
-        if (cpuid_info.max_xcpuid >= 0x80000006) {
-            cpuid(0x80000006, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[2],
-                &cpuid_info.cache_info.raw[3]
-            );
-        }
-        break;
-      case 'C':
-        if (cpuid_info.vendor_id.str[5] == 'I') break; // Cyrix
-        // VIA / CentaurHauls
-        if (cpuid_info.max_xcpuid >= 0x80000005) {
-            cpuid(0x80000005, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[0],
-                &cpuid_info.cache_info.raw[1]
-            );
-        }
-        if (cpuid_info.max_xcpuid >= 0x80000006) {
-            cpuid(0x80000006, 0,
-                &reg[0],
-                &reg[1],
-                &cpuid_info.cache_info.raw[2],
-                &cpuid_info.cache_info.raw[3]
-            );
-        }
-        break;
-      case 'G':
-        // Intel Processors
-        // No cpuid info to read.
-        break;
+    if (cpuid_info.max_xcpuid >= 0x80000005) {
+        cpuid(0x80000005, 0,
+            &reg[0],
+            &reg[1],
+            &cpuid_info.cache_info.raw[0],
+            &cpuid_info.cache_info.raw[1]
+        );
+    }
+    if (cpuid_info.max_xcpuid >= 0x80000006) {
+        cpuid(0x80000006, 0,
+            &reg[0],
+            &reg[1],
+            &cpuid_info.cache_info.raw[2],
+            &cpuid_info.cache_info.raw[3]
+        );
     }
 
     // Detect CPU Topology (Core/Thread) infos

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -632,9 +632,9 @@ static void determine_cpu_model(void)
         // Transmeta Processors - vendor_id starts with "GenuineTMx86"
         if (cpuid_info.vendor_id.str[7] == 'T' ) {
             if (cpuid_info.version.family == 5) {
-                cpu_model = "TM 5x00";
+                cpu_model = "Transmeta TM 5x00";
             } else if (cpuid_info.version.family == 15) {
-                cpu_model = "TM 8x00";
+                cpu_model = "Transmeta TM 8x00";
             }
             l1_cache = cpuid_info.cache_info.l1_i_size + cpuid_info.cache_info.l1_d_size;
             l2_cache = cpuid_info.cache_info.l2_size;
@@ -802,7 +802,7 @@ static void determine_cpu_model(void)
             // CentaurHauls
             switch (cpuid_info.version.family) {
               case 5:
-                cpu_model = "WinChip C6";
+                cpu_model = "IDT WinChip C6";
                 l1_cache = 32;
                 // WinChip 2/3 (models 8/9) have brand string
                 break;

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -680,14 +680,14 @@ static void determine_cpu_model(void)
               case 2:
               case 3:
               case 7:
-                cpu_model = "Pentium";
+                cpu_model = "Intel Pentium";
                 if (l1_cache == 0) {
                     l1_cache = 8;
                 }
                 break;
               case 4:
               case 8:
-                cpu_model = "Pentium-MMX";
+                cpu_model = "Intel Pentium MMX";
                 if (l1_cache == 0) {
                     l1_cache = 16;
                 }
@@ -700,54 +700,54 @@ static void determine_cpu_model(void)
             switch (cpuid_info.version.model) {
               case 0:
               case 1:
-                cpu_model = "Pentium Pro";
+                cpu_model = "Intel Pentium Pro";
                 break;
               case 3:
               case 4:
-                cpu_model = "Pentium II";
+                cpu_model = "Intel Pentium II";
                 break;
               case 5:
                 if (l2_cache == 0) {
-                    cpu_model = "Celeron";
+                    cpu_model = "Intel Celeron";
                 } else {
-                    cpu_model = "Pentium II";
+                    cpu_model = "Intel Pentium II";
                 }
                 break;
               case 6:
                 if (l2_cache == 128) {
-                  cpu_model = "Celeron";
+                  cpu_model = "Intel Celeron";
                 } else {
-                  cpu_model = "Pentium II";
+                  cpu_model = "Intel Pentium II";
                 }
                 break;
               case 7:
               case 8:
               case 11:
                 if (l2_cache == 128) {
-                    cpu_model = "Celeron";
+                    cpu_model = "Intel Celeron";
                 } else {
-                    cpu_model = "Pentium III";
+                    cpu_model = "Intel Pentium III";
                 }
                 break;
               case 9:
                 if (l2_cache == 512) {
-                    cpu_model = "Celeron M (0.13)";
+                    cpu_model = "Intel Celeron M (0.13)";
                 } else {
-                    cpu_model = "Pentium M (0.13)";
+                    cpu_model = "Intel Pentium M (0.13)";
                 }
                 break;
               case 10:
-                cpu_model = "Pentium III Xeon";
+                cpu_model = "Intel Pentium III Xeon";
                 break;
               case 12:
                 l1_cache = 24;
-                cpu_model = "Atom (0.045)";
+                cpu_model = "Intel Atom (0.045)";
                 break;
               case 13:
                 if (l2_cache == 1024) {
-                    cpu_model = "Celeron M (0.09)";
+                    cpu_model = "Intel Celeron M (0.09)";
                 } else {
-                    cpu_model = "Pentium M (0.09)";
+                    cpu_model = "Intel Pentium M (0.09)";
                 }
                 break;
               case 14:
@@ -755,7 +755,7 @@ static void determine_cpu_model(void)
                 break;
               case 15:
                 if (l2_cache == 1024) {
-                    cpu_model = "Pentium E";
+                    cpu_model = "Intel Pentium E";
                 } else {
                     cpu_model = "Intel Core 2";
                 }
@@ -770,17 +770,17 @@ static void determine_cpu_model(void)
               case 1:
               case 2:
                 if (l2_cache == 128) {
-                    cpu_model = "Celeron";
+                    cpu_model = "Intel Celeron";
                 } else {
-                    cpu_model = "Pentium 4";
+                    cpu_model = "Intel Pentium 4";
                 }
                 break;
               case 3:
               case 4:
                 if (l2_cache == 256) {
-                    cpu_model = "Celeron (0.09)";
+                    cpu_model = "Intel Celeron (0.09)";
                 } else {
-                    cpu_model = "Pentium 4 (0.09)";
+                    cpu_model = "Intel Pentium 4 (0.09)";
                 }
                 break;
               case 6:
@@ -844,10 +844,10 @@ static void determine_cpu_model(void)
         // Unknown processor - make a guess at the family.
         switch (cpuid_info.version.family) {
           case 5:
-            cpu_model = "586";
+            cpu_model = "586-class CPU (unknown)";
             break;
           case 6:
-            cpu_model = "686";
+            cpu_model = "686-class CPU (unknown)";
             break;
           default:
             cpu_model = "Unidentified Processor";


### PR DESCRIPTION
Always populate the cache info from extended CPUID, it is not used for Intel CPUs, even though it is present, and is useful for non-Intel CPUs.

Fix the CPU name and cache sizes for Centaur and Cyrix/NSC CPUs without brand string, which are the WinChip C6 and all Cyrix CPUs except the Media GXm.

For the Media GXm and Geode GXm/GXLV/GX1, which are available with both Cyrix and NSC vendor strings, hardcode the L1 cache size. The Geode GX2 uses standard cache info.