### PR TITLE
[Temperature] Add support for CPUs with specific TjMax

### DIFF
--- a/system/temperature.c
+++ b/system/temperature.c
@@ -33,32 +33,55 @@ float cpu_temp_offset = 0;
 // Public Functions
 //------------------------------------------------------------------------------
 
+int TjMax = 0;
+
+uint32_t regl, regh;
+
+void get_specific_TjMax(void)
+{
+    // The TjMax value for some Mobile/Embedded CPUs must be read from a fixed
+    // table according to their CPUID, PCI Root DID/VID or PNS.
+    // Trying to read the MSR 0x1A2 on some of them trigger a reboot.
+
+    // Yonah C0 Step (Pentium/Core Duo T2000 & Celeron M 200/400)
+    if (cpuid_info.version.raw[0] == 0x6E8) {
+        TjMax = 100;
+    }
+}
+
 void temperature_init(void)
 {
     // Process temperature-related quirks
     if (quirk.type & QUIRK_TYPE_TEMP) {
         quirk.process();
     }
+
+    // Get TjMax for Intel CPU
+    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
+
+        get_specific_TjMax();
+
+        if (TjMax == 0) {
+            // Generic Method using MSR 0x1A2
+            rdmsr(MSR_IA32_TEMPERATURE_TARGET, regl, regh);
+            TjMax = (regl >> 16) & 0x7F;
+
+            if (TjMax < 50 || TjMax > 125) {
+                TjMax = 100;
+            }
+        }
+    }
 }
 
 int get_cpu_temperature(void)
 {
     // Intel CPU
-    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6) {
-        if (cpuid_info.dts_pmp & 1) {
-            uint32_t msrl, msrh;
+    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
 
-            rdmsr(MSR_IA32_THERM_STATUS, msrl, msrh);
-            int Tabs = (msrl >> 16) & 0x7F;
+        rdmsr(MSR_IA32_THERM_STATUS, regl, regh);
+        int Tabs = (regl >> 16) & 0x7F;
 
-            rdmsr(MSR_IA32_TEMPERATURE_TARGET, msrl, msrh);
-            int Tjunc = (msrl >> 16) & 0x7F;
-
-            if (Tjunc < 50 || Tjunc > 125) {
-                Tjunc = 90;
-            }
-            return Tjunc - Tabs;
-        }
+        return TjMax - Tabs;
     }
 
     // AMD CPU
@@ -66,25 +89,25 @@ int get_cpu_temperature(void)
 
         if (cpuid_info.version.extendedFamily >= 8) {        // Target Zen µarch and newer. Use SMN to get temperature.
 
-            uint32_t tval = amd_smn_read(SMN_THM_TCON_CUR_TMP);
+            regl = amd_smn_read(SMN_THM_TCON_CUR_TMP);
 
-            if ((tval >> 19) & 0x01) {
-              cpu_temp_offset = -49.0f;
+            if ((regl >> 19) & 0x01) {
+                cpu_temp_offset = -49.0f;
             }
 
-            return cpu_temp_offset + 0.125f * (float)((tval >> 21) & 0x7FF);
+            return cpu_temp_offset + 0.125f * (float)((regl >> 21) & 0x7FF);
 
         } else if (cpuid_info.version.extendedFamily > 0) { // Target K10 to K15 (Bulldozer)
 
-            uint32_t rtcr = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K10);
-            int raw_temp = ((rtcr >> 21) & 0x7FF) / 8;
+            regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K10);
+            int raw_temp = ((regl >> 21) & 0x7FF) / 8;
 
             return (raw_temp > 0) ? raw_temp : 0;
 
         } else {                                            // Target K8 (CPUID ExtFamily = 0)
 
-            uint32_t rtcr = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K8);
-            int raw_temp = ((rtcr >> 16) & 0xFF) - 49 + cpu_temp_offset;
+            regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K8);
+            int raw_temp = ((regl >> 16) & 0xFF) - 49 + cpu_temp_offset;
 
             return (raw_temp > 0) ? raw_temp : 0;
         }
@@ -94,7 +117,7 @@ int get_cpu_temperature(void)
     else if (cpuid_info.vendor_id.str[0] == 'C' && cpuid_info.vendor_id.str[1] == 'e'
           && (cpuid_info.version.family == 6 || cpuid_info.version.family == 7)) {
 
-        uint32_t msrl, msrh, msr_temp;
+        uint32_t msr_temp;
 
         if (cpuid_info.version.family == 7 || cpuid_info.version.model == 0xF) {
             msr_temp = MSR_VIA_TEMP_NANO;   // Zhaoxin, Nano
@@ -104,8 +127,8 @@ int get_cpu_temperature(void)
             return 0;
         }
 
-        rdmsr(msr_temp, msrl, msrh);
-        return (int)(msrl & 0xffffff);
+        rdmsr(msr_temp, regl, regh);
+        return (int)(regl & 0xffffff);
     }
 
     return 0;

--- a/system/temperature.c
+++ b/system/temperature.c
@@ -33,9 +33,7 @@ float cpu_temp_offset = 0;
 // Public Functions
 //------------------------------------------------------------------------------
 
-int TjMax = 0;
-
-uint32_t regl, regh;
+static int TjMax = 0;
 
 void get_specific_TjMax(void)
 {
@@ -51,6 +49,8 @@ void get_specific_TjMax(void)
 
 void temperature_init(void)
 {
+    uint32_t regl, regh;
+
     // Process temperature-related quirks
     if (quirk.type & QUIRK_TYPE_TEMP) {
         quirk.process();
@@ -75,6 +75,8 @@ void temperature_init(void)
 
 int get_cpu_temperature(void)
 {
+    uint32_t regl, regh;
+
     // Intel CPU
     if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
 


### PR DESCRIPTION
Solve an issue where reading MSR_IA32_TEMPERATURE_TARGET makes the system crash (Celeron M 215 / Intel D201GLY board)