### PR TITLE
temperature: Refactor to separate detection and read

### DIFF
--- a/system/temperature.c
+++ b/system/temperature.c
@@ -44,7 +44,6 @@ typedef enum {
 } cpu_temp_t;
 
 static cpu_temp_t cpu_temp_type;
-static cpu_temp_t get_cpu_temp_type(void);
 
 static int TjMax = 0;
 
@@ -58,16 +57,6 @@ static void get_specific_TjMax(void)
     if (cpuid_info.version.raw[0] == 0x6E8) {
         TjMax = 100;
     }
-}
-
-void temperature_init(void)
-{
-    // Process temperature-related quirks
-    if (quirk.type & QUIRK_TYPE_TEMP) {
-        quirk.process();
-    }
-
-    cpu_temp_type = get_cpu_temp_type();
 }
 
 static cpu_temp_t get_cpu_temp_type(void)
@@ -118,6 +107,16 @@ static cpu_temp_t get_cpu_temp_type(void)
     return None;
 }
 
+void temperature_init(void)
+{
+    // Process temperature-related quirks
+    if (quirk.type & QUIRK_TYPE_TEMP) {
+        quirk.process();
+    }
+
+    cpu_temp_type = get_cpu_temp_type();
+}
+
 int get_cpu_temperature(void)
 {
     uint32_t regl, regh;
@@ -158,6 +157,9 @@ int get_cpu_temperature(void)
       case ViaC7:
         rdmsr(MSR_VIA_TEMP_C7, regl, regh);
         return (int)(regl & 0xffffff);
+
+      case None:
+        break;
     }
 
     return 0;

--- a/system/temperature.c
+++ b/system/temperature.c
@@ -33,9 +33,22 @@ float cpu_temp_offset = 0;
 // Public Functions
 //------------------------------------------------------------------------------
 
+typedef enum {
+    None,
+    Intel,
+    AmdZen,
+    AmdK10,
+    AmdK8,
+    ViaNano,
+    ViaC7
+} cpu_temp_t;
+
+static cpu_temp_t cpu_temp_type;
+static cpu_temp_t get_cpu_temp_type(void);
+
 static int TjMax = 0;
 
-void get_specific_TjMax(void)
+static void get_specific_TjMax(void)
 {
     // The TjMax value for some Mobile/Embedded CPUs must be read from a fixed
     // table according to their CPUID, PCI Root DID/VID or PNS.
@@ -49,16 +62,21 @@ void get_specific_TjMax(void)
 
 void temperature_init(void)
 {
-    uint32_t regl, regh;
-
     // Process temperature-related quirks
     if (quirk.type & QUIRK_TYPE_TEMP) {
         quirk.process();
     }
 
-    // Get TjMax for Intel CPU
-    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
+    cpu_temp_type = get_cpu_temp_type();
+}
 
+static cpu_temp_t get_cpu_temp_type(void)
+{
+    uint32_t regl, regh;
+
+    // Intel CPU
+    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
+        // Get TjMax for Intel CPU
         get_specific_TjMax();
 
         if (TjMax == 0) {
@@ -70,48 +88,19 @@ void temperature_init(void)
                 TjMax = 100;
             }
         }
-    }
-}
 
-int get_cpu_temperature(void)
-{
-    uint32_t regl, regh;
-
-    // Intel CPU
-    if (cpuid_info.vendor_id.str[0] == 'G' && cpuid_info.max_cpuid >= 6 && (cpuid_info.dts_pmp & 1)) {
-
-        rdmsr(MSR_IA32_THERM_STATUS, regl, regh);
-        int Tabs = (regl >> 16) & 0x7F;
-
-        return TjMax - Tabs;
+        return Intel;
     }
 
     // AMD CPU
     else if (cpuid_info.vendor_id.str[0] == 'A' && cpuid_info.version.family == 0xF) { // Target only K8 & newer
 
         if (cpuid_info.version.extendedFamily >= 8) {        // Target Zen µarch and newer. Use SMN to get temperature.
-
-            regl = amd_smn_read(SMN_THM_TCON_CUR_TMP);
-
-            if ((regl >> 19) & 0x01) {
-                cpu_temp_offset = -49.0f;
-            }
-
-            return cpu_temp_offset + 0.125f * (float)((regl >> 21) & 0x7FF);
-
+            return AmdZen;
         } else if (cpuid_info.version.extendedFamily > 0) { // Target K10 to K15 (Bulldozer)
-
-            regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K10);
-            int raw_temp = ((regl >> 21) & 0x7FF) / 8;
-
-            return (raw_temp > 0) ? raw_temp : 0;
-
+            return AmdK10;
         } else {                                            // Target K8 (CPUID ExtFamily = 0)
-
-            regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K8);
-            int raw_temp = ((regl >> 16) & 0xFF) - 49 + cpu_temp_offset;
-
-            return (raw_temp > 0) ? raw_temp : 0;
+            return AmdK8;
         }
     }
 
@@ -119,17 +108,55 @@ int get_cpu_temperature(void)
     else if (cpuid_info.vendor_id.str[0] == 'C' && cpuid_info.vendor_id.str[1] == 'e'
           && (cpuid_info.version.family == 6 || cpuid_info.version.family == 7)) {
 
-        uint32_t msr_temp;
-
         if (cpuid_info.version.family == 7 || cpuid_info.version.model == 0xF) {
-            msr_temp = MSR_VIA_TEMP_NANO;   // Zhaoxin, Nano
+            return ViaNano;                 // Zhaoxin, Nano
         } else if (cpuid_info.version.model == 0xA || cpuid_info.version.model == 0xD) {
-            msr_temp = MSR_VIA_TEMP_C7;     // C7 A/D
-        } else {
-            return 0;
+            return ViaC7;                   // C7 A/D
+        }
+    }
+
+    return None;
+}
+
+int get_cpu_temperature(void)
+{
+    uint32_t regl, regh;
+    int raw_temp;
+
+    switch (cpu_temp_type) {
+      case Intel:
+        rdmsr(MSR_IA32_THERM_STATUS, regl, regh);
+        raw_temp = (regl >> 16) & 0x7F;
+
+        return TjMax - raw_temp;
+
+      case AmdZen:
+        regl = amd_smn_read(SMN_THM_TCON_CUR_TMP);
+
+        if ((regl >> 19) & 0x01) {
+            cpu_temp_offset = -49.0f;
         }
 
-        rdmsr(msr_temp, regl, regh);
+        return cpu_temp_offset + 0.125f * (float)((regl >> 21) & 0x7FF);
+
+      case AmdK10:
+        regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K10);
+        raw_temp = ((regl >> 21) & 0x7FF) / 8;
+
+        return (raw_temp > 0) ? raw_temp : 0;
+
+      case AmdK8:
+        regl = pci_config_read32(0, 24, 3, AMD_TEMP_REG_K8);
+        raw_temp = ((regl >> 16) & 0xFF) - 49 + cpu_temp_offset;
+
+        return (raw_temp > 0) ? raw_temp : 0;
+
+      case ViaNano:
+        rdmsr(MSR_VIA_TEMP_NANO, regl, regh);
+        return (int)(regl & 0xffffff);
+
+      case ViaC7:
+        rdmsr(MSR_VIA_TEMP_C7, regl, regh);
         return (int)(regl & 0xffffff);
     }
 


### PR DESCRIPTION
Move the detection of the temperature sensor type based on CPUID to temperature_init and store the type in an enum. This allows get_cpu_temperature to use a simpler switch on that enum.