### PR TITLE
Revert pre-enabled x2APIC by BIOS to xAPIC

### DIFF
--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -152,6 +152,25 @@ startup:
 
 	leaq	startup_stack_top(%rip), %rsp
 
+    # Disable x2APIC if supported & enabled
+
+    movl	$0x1, %eax
+    cpuid
+    notl	%ecx
+    andl	$0x200000, %ecx
+    jnz	nox2apic				# x2APIC supported?
+    movq	$0x1b, %rcx
+    rdmsr
+    notl	%eax
+    andl	$0xc00, %eax		# x2APIC enabled?
+    jnz	nox2apic
+    rdmsr
+    andl	$0xfffff3ff, %eax	# Disable xAPIC & x2APIC
+    wrmsr
+    orl	$0x800, %eax			# Enable xAPIC only
+    wrmsr
+nox2apic:
+
 	# Pick the correct stack.
 
 	xorq	%rax, %rax

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -152,23 +152,23 @@ startup:
 
 	leaq	startup_stack_top(%rip), %rsp
 
-    # Disable x2APIC if supported & enabled
+	# Disable x2APIC if supported & enabled on APs
 
-    movl	$0x1, %eax
-    cpuid
-    notl	%ecx
-    andl	$0x200000, %ecx
-    jnz	nox2apic				# x2APIC supported?
-    movq	$0x1b, %rcx
-    rdmsr
-    notl	%eax
-    andl	$0xc00, %eax		# x2APIC enabled?
-    jnz	nox2apic
-    rdmsr
-    andl	$0xfffff3ff, %eax	# Disable xAPIC & x2APIC
-    wrmsr
-    orl	$0x800, %eax			# Enable xAPIC only
-    wrmsr
+	movl	$0x1, %eax
+	cpuid
+	notl	%ecx
+	andl	$0x200000, %ecx
+	jnz	nox2apic				# x2APIC supported?
+	movq	$0x1b, %rcx
+	rdmsr
+	notl	%eax
+	andl	$0xc00, %eax		# x2APIC enabled?
+	jnz	nox2apic
+	rdmsr
+	andl	$0xfffff3ff, %eax	# Disable xAPIC & x2APIC
+	wrmsr
+	orl	$0x800, %eax			# Enable xAPIC only
+	wrmsr
 nox2apic:
 
 	# Pick the correct stack.

--- a/system/smp.c
+++ b/system/smp.c
@@ -540,7 +540,7 @@ bool check_x2apic(void)
         rdmsr(MSR_IA32_APIC_BASE, reg[0], reg[1]);
 #endif
         if ((reg[0] & IA32_APIC_ENABLED) && (reg[0] & IA32_APIC_EXTENDED)) {
-            // x2APIC is still enabled. Give up.
+            // x2APIC is still enabled (or binary is 32 bit). Give up.
             return false;
         }
     }


### PR DESCRIPTION
Here's something we need to discuss. I'm working on full x2APIC support, but debugging is long and painful (messing with MSRs is a good way to experience a massive amount of GPFs...). 

Some weeks ago, a betatester needed a way to test an ES server (Intel SPR) with SMP enabled, but x2APIC was also enabled (and no way to disable it with a BIOS option), so I wrote a quick patch to disable x2APIC and revert back to xAPIC. It worked fine. 

I tuned it a bit and removed a lot of superfluous ASM checks for APs. It's now extremely small and seems to work as expected on platforms with x2APIC pre-enabled. 

To me, it solved 95+% of the issues we currently have with x2APIC (no SMT at all when x2APIC is enabled), leaving the remaining 5% (support for > 255 cores, which I still question the advantage for Memtest86+) to do. 

Should we start betatesting this for addition in main (before a cleaner but much longer x2APIC implementation in the future)?