### PR TITLE
cpuinfo: Add support for Vortex86

### DIFF
--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -92,7 +92,7 @@ static void determine_cache_size()
         /* fall through */
       case 'V':
         // Vortex86
-        if (cpuid_info.version.family < 6) {
+        if (cpuid_info.vendor_id.str[0] == 'V' && cpuid_info.version.family < 6) {
           // Only family 6 have cache info
           break;
         }

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -867,9 +867,13 @@ static void determine_cpu_model(void)
                 break;
             }
             break;
-
+          case 6:
+            // Other family 6 models have brand string
+            cpu_model = "Vortex86EX";
+            l1_cache = 16;
+            l2_cache = 128;
+            break;
           default:
-            // All Vortex86 family values >= 6 have brand string
             break;
         }
         break;

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -90,6 +90,13 @@ static void determine_cache_size()
         }
         // Zhaoxin CPU only
         /* fall through */
+      case 'V':
+        // Vortex86
+        if (cpuid_info.version.family < 6) {
+          // Only family 6 have cache info
+          break;
+        }
+        /* fall through */
       case 'G':
         if (cpuid_info.vendor_id.str[9] == 'N') {
           // National Semiconductor
@@ -840,6 +847,33 @@ static void determine_cpu_model(void)
             }
         }
         break;
+
+      case 'V':
+        // Vortex86 SoC
+        switch (cpuid_info.version.family) {
+          case 5:
+            switch (cpuid_info.version.model) {
+              case 2:
+                cpu_model = "Vortex86DX";
+                l1_cache = 16;
+                l2_cache = 256;
+                break;
+              case 8:
+                cpu_model = "Vortex86MX/DX2";
+                l1_cache = 16;
+                l2_cache = 256;
+                break;
+              default:
+                break;
+            }
+            break;
+
+          default:
+            // All Vortex86 family values >= 6 have brand string
+            break;
+        }
+        break;
+
       default:
         // Unknown processor - make a guess at the family.
         switch (cpuid_info.version.family) {


### PR DESCRIPTION
Hardcode cache for family 5, use CPUID cache info for family 6.