### PR TITLE
Enable using custom objcopy during build.

### DIFF
--- a/build32/Makefile
+++ b/build32/Makefile
@@ -1,5 +1,6 @@
 AS = as -32
 CC = gcc
+OBJCOPY = objcopy
 
 GIT = git
 
@@ -133,7 +134,7 @@ memtest_shared: $(OBJS) ldscripts/memtest_shared.lds Makefile
 	$(LD) -shared -Bsymbolic -T ldscripts/memtest_shared.lds -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared
-	objcopy -O binary $< memtest_shared.bin
+	$(OBJCOPY) -O binary $< memtest_shared.bin
 
 memtest.bin: memtest_shared.bin boot/bootsect.o boot/setup.o ldscripts/memtest_bin.lds
 	$(eval SIZES=$(shell size -B -d memtest_shared | grep memtest_shared))

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -1,5 +1,6 @@
 AS = as -64
 CC = gcc
+OBJCOPY = objcopy
 
 GIT = git
 
@@ -132,7 +133,7 @@ memtest_shared: $(OBJS) ldscripts/memtest_shared.lds Makefile
 	$(LD) -shared -Bsymbolic -T ldscripts/memtest_shared.lds -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared
-	objcopy -O binary $< memtest_shared.bin
+	$(OBJCOPY) -O binary $< memtest_shared.bin
 
 memtest.bin: memtest_shared.bin boot/bootsect.o boot/setup.o ldscripts/memtest_bin.lds
 	$(eval SIZES=$(shell size -B -d memtest_shared | grep memtest_shared))


### PR DESCRIPTION
When cross compiling the unqualified `objcopy` found on the host might not be able to deal with x86 binaries.