### PR TITLE
Display DDR5 SPD5 Hub memory modules temperature

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -351,6 +351,11 @@ void display_temperature(void)
 
     clear_screen_region(1, 18, 1, 22);
     printf(1, 20-offset, "%2i/%2i%cC", actual_cpu_temp, max_cpu_temp, 0xF8);
+
+    // Display DDR5 temperatures.
+    // TODO: Reading temperature from SPD5 involes I2C IO operations, which
+    // may introduce unnecessary delay in the main thread.
+    print_ddr5_temperature();
 }
 
 void display_big_status(bool pass)

--- a/system/smbus.h
+++ b/system/smbus.h
@@ -13,7 +13,12 @@
 #define I2C_WRITE   0
 #define I2C_READ    1
 
+/* SPD5 Hub I2C Legacy Mode Device Configuration */
 #define SPD5_MR11 11
+/* SPD5 Hub TS Current Sensed Temperature - Low Byte */
+#define SPD5_MR49 49
+/* SPD5 Hub TS Current Sensed Temperature - Low Byte */
+#define SPD5_MR50 50
 
 /* i801 Hosts Addresses */
 #define SMBHSTSTS   smbusbase
@@ -155,5 +160,10 @@ extern ram_info ram;
  */
 
 void print_smbus_startup_info(void);
+
+/**
+ * Print DDR5 temperatures. No-op if not DDR5.
+ */
+void print_ddr5_temperature(void);
 
 #endif // SMBUS_H


### PR DESCRIPTION
This is a PoC for reading and displaying DDR5 SPD5 Hub temperature for https://github.com/memtest86plus/memtest86plus/issues/302

Example of how it looks on my system:
![image](https://user-images.githubusercontent.com/46573/236700213-a0f87745-8f29-477d-9278-2687862a557d.png)

Marking as PoC as there are few unresolved items (there are also TODOs in the code):

1. Currently displaying the temperature to the right of SPD information about memory modules. This is a bad location, as it overlaps with error strings that Memtest will display on memory errors, plus potentially overlaps with long description lines from SPD. What would be the best place to display this information and how much of information should be displayed?

2. Temperature readings require I2C/SMBus IO operations, which are generally slow (e.g. `usleep()` in [`ich5_process()`](https://github.com/memtest86plus/memtest86plus/blob/5dcd424ea7afb857c1171e747ef064d98d26afeb/system/smbus.c#L1587)). Currently the updates are hacked into the same place where CPU temperature updates are written, which happen only once per second. But I'm unsure if sleeping during I2C/SMBus IO operation would negatively affect other stuff (actual test runs?) done in the same thread.

3. Temperature reads always using `ich5`/`i801` code path. Not sure if other SMBus implementations need to be supported.

4. SPD5 Hub without temperature sensor. Can be easily checked in the code by reading the relevant register.

Tested on ASUS Z690 with 4x32 GB Kingston Fury DDR5 (listed on the screenshot above).

Not really tested:

* Running with less than 4 sticks (e.g. when used slots list has gaps, like only 1 and 3 slots used).
* How errors will looks like (but should overlap with the displayed temperature strings).
* Output to TTY (only tested with output to actual screen).
