### PR TITLE
Fix memory error addresses displayed by badram reporting mode

### DIFF
--- a/app/badram.h
+++ b/app/badram.h
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "test.h"
+
 /**
  * Initialises the pattern array.
  */
@@ -22,7 +24,7 @@ void badram_init(void);
  * Inserts a single faulty address into the pattern array. Returns
  * true iff the array was changed.
  */
-bool badram_insert(uintptr_t addr);
+bool badram_insert(testword_t page, testword_t offset);
 
 /**
  * Displays the pattern array in the scrollable display region in the

--- a/app/test.h
+++ b/app/test.h
@@ -47,19 +47,33 @@ extern barrier_t *run_barrier;
  */
 extern spinlock_t *error_mutex;
 
+#ifdef __x86_64__
 /**
  * The word width (in bits) used for memory testing.
  */
-#ifdef __x86_64__
-#define TESTWORD_WIDTH  64
-#else
-#define TESTWORD_WIDTH  32
-#endif
-
+#define TESTWORD_WIDTH       64
 /**
  * The number of hex digits needed to display a memory test word.
  */
-#define TESTWORD_DIGITS (TESTWORD_WIDTH / 4)
+#define TESTWORD_DIGITS      16
+/**
+ * The string representation of TESTWORDS_DIGITS
+ */
+#define TESTWORD_DIGITS_STR "16"
+#else
+/**
+ * The word width (in bits) used for memory testing.
+ */
+#define TESTWORD_WIDTH      32
+/**
+ * The number of hex digits needed to display a memory test word.
+ */
+#define TESTWORD_DIGITS      8
+/**
+ * The string representation of TESTWORDS_DIGITS
+ */
+#define TESTWORD_DIGITS_STR "8"
+#endif
 
 /**
  * The word type used for memory testing.


### PR DESCRIPTION
Per the discussion in #308.

I have tested this fix on top of the `numa` branch, since that's where I'm running the debugger using a modified version of  #177. I used the following patch to interfere with the contents of the memory at an address in the third 1 GB directory page, in order to generate multiple errors when there's enough memory:
```
diff --git a/tests/own_addr.c b/tests/own_addr.c
index 23db5ec..f20a777 100644
--- a/tests/own_addr.c
+++ b/tests/own_addr.c
@@ -125,7 +125,7 @@ static int pattern_check(int my_cpu, testword_t offset)
             if (!offset) {
                 do {
                     testword_t expect = (testword_t)p;
-                    testword_t actual = read_word(p);
+                    testword_t actual = (p == (testword_t *)2345678912) ? (testword_t)0 : read_word(p);
                     if (unlikely(actual != expect)) {
                         data_error(p, expect, actual, true);
                     }
@@ -134,7 +134,7 @@ static int pattern_check(int my_cpu, testword_t offset)
             else {
                 do {
                     testword_t expect = (testword_t)p + offset;
-                    testword_t actual = read_word(p);
+                    testword_t actual = (p == (testword_t *)2345678912) ? (testword_t)0 : read_word(p);
                     if (unlikely(actual != expect)) {
                         data_error(p, expect, actual, true);
                     }
```

When executing `debug_memtest.sh` with the `MACHINE=2S12CWestmere MEMSIZE=8192` environment variables:
* the individual error reporting mode keeps reporting correct errors (2345678912 = 0x8bd03840, and QEMU has a memory hole between 2 GB and 4 GB):
![memtest86plus_badram_fix_test_20230521_04](https://github.com/memtest86plus/memtest86plus/assets/8375/5f96bf83-b7ce-4973-9277-a81836eaabe6)
* without this fix, the badram error reporting mode incorrectly merges error reports to a single error at a physical address inside the memory hole range:
![memtest86plus_badram_fix_test_20230521_02](https://github.com/memtest86plus/memtest86plus/assets/8375/2e5fbe18-b9b0-49e1-920a-b286a1341453)
* with this fix, the badram error reporting mode reports the same set of 6 errors as the individual error reporting mode:
![memtest86plus_badram_fix_test_20230521_03](https://github.com/memtest86plus/memtest86plus/assets/8375/9899837d-c92c-48eb-89e4-20aaa68fb9d9)