### PR TITLE
cpuinfo: Fix VIA Samuel 2 L2 cache

### DIFF
--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -80,6 +80,10 @@ static void determine_cache_size()
         if (cpuid_info.version.family == 5 || cpuid_info.version.family == 6) {
             l1_cache = cpuid_info.cache_info.l1_d_size;
             l2_cache = cpuid_info.cache_info.l2_size;
+            if (cpuid_info.version.family == 6 && (cpuid_info.version.model == 7 || cpuid_info.version.model == 8)) {
+                // Samuel 2/Ezra/Ezra-T
+                l2_cache >>= 8;
+            }
             break;
         } else if (cpuid_info.version.family != 7) {
             break;

--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -82,7 +82,7 @@ static void determine_cache_size()
             l2_cache = cpuid_info.cache_info.l2_size;
             if (cpuid_info.version.family == 6 && (cpuid_info.version.model == 7 || cpuid_info.version.model == 8)) {
                 // Samuel 2/Ezra/Ezra-T
-                l2_cache >>= 8;
+                l2_cache = 64;
             }
             break;
         } else if (cpuid_info.version.family != 7) {


### PR DESCRIPTION
Centaur family 6 models 7/8 only use the MSB to report L2 cache size. Fix it by right-shifting by 8.