### PR TITLE
Add "singlepass" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ recognised:
       * mmio16 = 16-bit MMIO
       * mmio32 = 32-bit MMIO
     * and *y* is the MMIO address in hex. with `0x` prefix (eg: 0xFEDC9000)
+  * singlepass
+    * performs one pass of selected tests then reboots rather than testing endlessly
 
 ## Keyboard Selection
 

--- a/app/config.c
+++ b/app/config.c
@@ -113,6 +113,8 @@ int             tty_mmio_stride    = 4;                 // Stride for MMIO (regi
 
 bool            err_banner_redraw  = false;             // Redraw banner on new errors
 
+bool            single_pass        = false;
+
 //------------------------------------------------------------------------------
 // Private Functions
 //------------------------------------------------------------------------------
@@ -263,6 +265,8 @@ static void parse_option(const char *option, const char *params)
         } else if (strncmp(params, "3", 2) == 0) {
             usb_init_options |= USB_2_STEP_INIT|USB_EXTRA_RESET;
         }
+    } else if (strncmp(option, "singlepass", 11) == 0) {
+        single_pass = true;
     }
 }
 
@@ -879,10 +883,16 @@ void config_menu(bool initial)
             printf(POP_R+8,  POP_LI, "<F6>  Temperature %s", enable_temperature ? "disable" : "enable ");
             //if (no_temperature) set_foreground_colour(WHITE);
             printf(POP_R+9,  POP_LI, "<F7>  Boot trace %s",  enable_trace  ? "disable" : "enable ");
-            prints(POP_R+10, POP_LI, "<F10> Exit menu");
+            printf(POP_R+10, POP_LI, "<F8>  Single pass %s",  single_pass  ? "disable" : "enable ");
+            prints(POP_R+11, POP_LI, "<F10> Exit menu");
         } else {
             prints(POP_R+7,  POP_LI, "<F5>  Skip current test");
-            prints(POP_R+8 , POP_LI, "<F10> Exit menu");
+            if (single_pass) {
+                prints(POP_R+8,  POP_LI, "<F6>  Run tests forever     ");
+            } else {
+                prints(POP_R+8,  POP_LI, "<F6>  End after current pass");
+            }
+            prints(POP_R+9,  POP_LI, "<F10> Exit menu");
         }
 
         if (tty_update) {
@@ -917,11 +927,18 @@ void config_menu(bool initial)
           case '6':
             if (initial) {
                 enable_temperature = !enable_temperature;
+            } else {
+                single_pass = !single_pass;
             }
             break;
           case '7':
             if (initial) {
                 enable_trace = !enable_trace;
+            }
+            break;
+          case '8':
+            if (initial) {
+                single_pass = !single_pass;
             }
             break;
           case '0':

--- a/app/config.h
+++ b/app/config.h
@@ -73,6 +73,8 @@ extern int          tty_mmio_stride;
 
 extern bool err_banner_redraw;
 
+extern bool         single_pass;
+
 void config_init(void);
 
 void config_menu(bool initial);

--- a/app/display.c
+++ b/app/display.c
@@ -388,7 +388,9 @@ void display_big_status(bool pass)
     }
 
     prints(POP_STAT_R+8, POP_STAT_C+5, "                                    ");
-    prints(POP_STAT_R+9, POP_STAT_C+5, "Press any key to remove this banner ");
+    if (!single_pass) {
+        prints(POP_STAT_R+9, POP_STAT_C+5, "Press any key to remove this banner ");
+    }
 
     set_background_colour(BLUE);
     set_foreground_colour(WHITE);

--- a/app/main.c
+++ b/app/main.c
@@ -677,6 +677,13 @@ void main(void)
             } else {
                 display_big_status(false);
             }
+            if (single_pass) {
+                display_status("Done   ");
+                if (enable_tty){
+                    tty_full_redraw();
+                }
+                reboot();
+            }
         }
     }
 }


### PR DESCRIPTION
Normally memtest86+ runs forever. Using this command line option causes it to exit/reboot after one pass of the selected tests is performed.

Also adds the feature as a menu option and if enabled from the menu during testing it will cause the memtest86+ to exit/reboot after the current pass is completed.