### PR TITLE
Add "tests" parameter to specify the tests to enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ recognised:
       * mmio16 = 16-bit MMIO
       * mmio32 = 32-bit MMIO
     * and *y* is the MMIO address in hex. with `0x` prefix (eg: 0xFEDC9000)
+  * tests=*list*
+    * where *list* is a hex bitmask of the tests to perform with `0x` prefix (eg: 0x7FB)
+      * each bit number corresponds to the test number (eg: bit 0 is test 0 and bit 10 is test 10)
 
 ## Keyboard Selection
 

--- a/app/config.c
+++ b/app/config.c
@@ -117,6 +117,16 @@ bool            err_banner_redraw  = false;             // Redraw banner on new 
 // Private Functions
 //------------------------------------------------------------------------------
 
+static void configure_tests_from_bitmask(uint32_t test_set)
+{
+    if ((test_set & ALL_TESTS_MASK) != 0) {
+        for (int i = 0; i < NUM_TEST_PATTERNS; i++) {
+            test_list[i].enabled = ((test_set & 0x1) == 0x1);
+            test_set = test_set >> 1;
+        }
+    }
+}
+        
 static void parse_serial_params(const char *params)
 {
     enable_tty = true;
@@ -262,6 +272,13 @@ static void parse_option(const char *option, const char *params)
             usb_init_options |= USB_EXTRA_RESET;
         } else if (strncmp(params, "3", 2) == 0) {
             usb_init_options |= USB_2_STEP_INIT|USB_EXTRA_RESET;
+        }
+    } else if (strncmp(option, "tests", 6) == 0) {
+        if (strncmp(params, "0x", 2) == 0) {
+            uint32_t tests = hexstr2int(params+2);
+            if ((tests & ALL_TESTS_MASK) != 0) {
+                configure_tests_from_bitmask(tests);
+            }
         }
     }
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -15,6 +15,7 @@
 #include "config.h"
 
 #define NUM_TEST_PATTERNS   11
+#define ALL_TESTS_MASK      ((1 << NUM_TEST_PATTERNS) - 1)
 
 typedef struct {
     bool            enabled;


### PR DESCRIPTION
Provides a mechanism through which the tests to be run can be specified on the command line.