### PR TITLE
Preliminary ECC support for AMD Zen CPUs

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -99,6 +99,8 @@ bool            enable_sm          = true;
 bool            enable_bench       = true;
 bool            enable_mch_read    = true;
 
+bool            enable_ecc_polling = false;
+
 bool            pause_at_start     = true;
 
 power_save_t    power_save         = POWER_SAVE_HIGH;

--- a/app/config.h
+++ b/app/config.h
@@ -59,6 +59,7 @@ extern bool         enable_sm;
 extern bool         enable_tty;
 extern bool         enable_bench;
 extern bool         enable_mch_read;
+extern bool         enable_ecc_polling;
 
 extern bool         pause_at_start;
 

--- a/app/display.h
+++ b/app/display.h
@@ -9,7 +9,7 @@
  *
  *//*
  * Copyright (C) 2020-2022 Martin Whitaker.
- * Copyright (C) 2004-2022 Sam Demeulemeester.
+ * Copyright (C) 2004-2023 Sam Demeulemeester.
  */
 
 #include <stdbool.h>
@@ -188,8 +188,14 @@ typedef enum {
 #define display_pass_count(count) \
     printi(8, 51, count, 0, false, true)
 
-#define display_error_count(count) \
+#define display_err_count_without_ecc(count) \
     printi(8, 68, count, 0, false, true)
+
+#define display_err_count_with_ecc(count_err, count_ecc) \
+    { \
+        printi(8, 62, count_err, 0, false, true); \
+        printi(8, 74, count_ecc, 0, false, true); \
+    }
 
 #define clear_message_area() \
     { \
@@ -244,6 +250,8 @@ void display_start_run(void);
 void display_start_pass(void);
 
 void display_start_test(void);
+
+void display_error_count(void);
 
 void display_temperature(void);
 

--- a/app/error.c
+++ b/app/error.c
@@ -22,9 +22,8 @@
 #include "test.h"
 
 #include "tests.h"
-
 #include "serial.h"
-
+#include "memctrl.h"
 #include "error.h"
 
 //------------------------------------------------------------------------------
@@ -39,7 +38,13 @@
 // Types
 //------------------------------------------------------------------------------
 
-typedef enum { ADDR_ERROR, DATA_ERROR, PARITY_ERROR, NEW_MODE } error_type_t;
+typedef enum { ADDR_ERROR,
+               DATA_ERROR,
+               PARITY_ERROR,
+               UECC_ERROR,
+               CECC_ERROR,
+               NEW_MODE
+} error_type_t;
 
 typedef struct {
     uintptr_t           page;
@@ -71,7 +76,8 @@ static error_info_t     error_info;
 // Public Variables
 //------------------------------------------------------------------------------
 
-uint64_t                error_count = 0;
+uint64_t                error_count      = 0;
+uint64_t                error_count_cecc = 0;
 
 //------------------------------------------------------------------------------
 // Private Functions
@@ -150,7 +156,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
 
     restore_big_status();
 
-    bool new_header = (error_count == 0) || (error_mode != last_error_mode);
+    bool new_header = (error_count == 0 && error_count_cecc == 0) || (error_mode != last_error_mode);
     if (new_header) {
         clear_message_area();
         badram_init();
@@ -184,11 +190,17 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
     }
 
     if (new_address) {
-        if (error_count < ERROR_LIMIT) {
-            error_count++;
-        }
-        if (test_list[test_num].errors < INT_MAX) {
-            test_list[test_num].errors++;
+        if (type == CECC_ERROR) {
+            if ((error_count_cecc + ecc_status.count) < 999999) {
+                error_count_cecc += ecc_status.count;
+            }
+        } else {
+            if (error_count < ERROR_LIMIT) {
+                error_count++;
+            }
+            if (test_list[test_num].errors < INT_MAX) {
+                test_list[test_num].errors++;
+            }
         }
     }
 
@@ -241,7 +253,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
                                        test_list[i].errors);
             }
 
-            display_error_count(error_count);
+            display_error_count();
         }
         break;
 
@@ -268,10 +280,15 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
             scroll();
 
             set_foreground_colour(YELLOW);
+
             display_scrolled_message(0, " %2i   %4i   %2i   %09x%03x (%kB)",
-                                     smp_my_cpu_num(), pass_num, test_num, page, offset, page << 2);
+                                     type != CECC_ERROR ? smp_my_cpu_num() : ecc_status.core,
+                                     pass_num, test_num, page, offset, page << 2);
+
             if (type == PARITY_ERROR) {
                 display_scrolled_message(41, "%s", "Parity error detected near this address");
+            } else if (type == CECC_ERROR) {
+                display_scrolled_message(41, "%s%2i", "Correctable ECC Error - CH#", ecc_status.channel);
             } else {
 #if TESTWORD_WIDTH > 32
                 display_scrolled_message(41, "%016x  %016x", good, bad);
@@ -279,9 +296,10 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
                 display_scrolled_message(41, "%08x  %08x  %08x  %i", good, bad, xor, error_count);
 #endif
             }
+
             set_foreground_colour(WHITE);
 
-            display_error_count(error_count);
+            display_error_count();
         }
         break;
 
@@ -295,7 +313,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
         break;
     }
 
-    if (type != PARITY_ERROR) {
+    if (type != PARITY_ERROR && type != CECC_ERROR) {
         error_info.last_addr = addr;
         error_info.last_xor  = xor;
     }
@@ -345,6 +363,12 @@ void data_error(testword_t *addr, testword_t good, testword_t bad, bool use_for_
     common_err(DATA_ERROR, (uintptr_t)addr, good, bad, use_for_badram);
 }
 
+void ecc_error()
+{
+    common_err(CECC_ERROR, ecc_status.addr, 0, 0, false);
+    error_update();
+}
+
 #if REPORT_PARITY_ERRORS
 void parity_error(void)
 {
@@ -356,7 +380,7 @@ void parity_error(void)
 
 void error_update(void)
 {
-    if (error_count > 0) {
+    if (error_count > 0 || error_count_cecc > 0) {
         if (error_mode != last_error_mode) {
             common_err(NEW_MODE, 0, 0, 0, false);
         }
@@ -365,12 +389,16 @@ void error_update(void)
                                    test_list[test_num].errors == INT_MAX ? '>' : ' ',
                                    test_list[test_num].errors);
         }
-        display_error_count(error_count);
-        display_status("Failed!");
+        display_error_count();
 
-        // Display FAIL banner on first error
-        if (error_count == 1) {
-            display_big_status(false);
+        // Only fail if error is uncorrected
+        if (error_count > 0) {
+            display_status("Failed!");
+
+            // Display FAIL banner on first uncorrectable error
+            if (error_count == 1) {
+                display_big_status(false);
+            }
         }
 
         if (enable_tty) {

--- a/app/error.h
+++ b/app/error.h
@@ -21,6 +21,11 @@
 extern uint64_t error_count;
 
 /**
+ * The number of correctable ECC errors recorded during the current run.
+ */
+extern uint64_t error_count_cecc;
+
+/**
  * Initialises the error records.
  */
 void error_init(void);
@@ -34,6 +39,12 @@ void addr_error(testword_t *addr1, testword_t *addr2, testword_t good, testword_
  * Adds a data error to the error reports.
  */
 void data_error(testword_t *addr, testword_t good, testword_t bad, bool use_for_badram);
+
+/**
+ * Adds an ECC error to the error reports.
+ * ECC Error details are stored in ecc_status
+ */
+void ecc_error();
 
 #if REPORT_PARITY_ERRORS
 /**

--- a/system/imc/amd_zen.c
+++ b/system/imc/amd_zen.c
@@ -6,6 +6,8 @@
 // Platform-specific code for AMD Zen CPUs
 //
 
+#include "error.h"
+
 #include "cpuinfo.h"
 #include "memctrl.h"
 #include "msr.h"
@@ -13,16 +15,33 @@
 
 #include "imc.h"
 
+#include "display.h" // DEBUG
+
 #define AMD_SMN_UMC_BAR             0x050000
 #define AMD_SMN_UMC_CHB_OFFSET      0x100000
+#define AMD_SMN_UMC_DRAM_ECC_CTRL   AMD_SMN_UMC_BAR + 0x14C
 #define AMD_SMN_UMC_DRAM_CONFIG     AMD_SMN_UMC_BAR + 0x200
 #define AMD_SMN_UMC_DRAM_TIMINGS1   AMD_SMN_UMC_BAR + 0x204
 #define AMD_SMN_UMC_DRAM_TIMINGS2   AMD_SMN_UMC_BAR + 0x208
+
+#define AMD_SMN_UMC_ECC_ERR_CNT_SEL AMD_SMN_UMC_BAR + 0xD80
+#define AMD_SMN_UMC_ECC_ERR_CNT     AMD_SMN_UMC_BAR + 0xD84
+
+#define AMD_UMC_OFFSET              0x10
+#define AMD_UMC_VALID_ERROR_BIT     (1 << 31)
+#define AMD_UMC_ERROR_CECC_BIT      (1 << 14)
+#define AMD_UMC_ERROR_UECC_BIT      (1 << 13)
+#define AMD_UMC_ERR_CNT_EN          (1 << 15)
+#define AMD_MCA_STATUS_WR_ENABLE    (1 << 18)
+
+#define ECC_RD_EN (1 << 10)
+#define ECC_WR_EN (1 << 0)
 
 void get_imc_config_amd_zen(void)
 {
     uint32_t smn_reg, offset;
     uint32_t reg_cha, reg_chb;
+    uint32_t regl, regh;
 
     imc.tCL_dec = 0;
 
@@ -68,4 +87,108 @@ void get_imc_config_amd_zen(void)
 
     // RAS Precharge (tRP)
     imc.tRP = (smn_reg >> 16) & 0x3F;
+
+    // Detect ECC (x64 only)
+#if TESTWORD_WIDTH > 32
+    smn_reg = amd_smn_read(AMD_SMN_UMC_DRAM_ECC_CTRL + offset);
+    if (smn_reg & (ECC_RD_EN | ECC_WR_EN)) {
+        ecc_status.ecc_enabled = true;
+
+        // Number of UMC to init
+        uint8_t umc = 0, umc_max = 0;
+
+        if (imc.family == IMC_K19_VRM || imc.family == IMC_K19_RPL) {
+            umc_max = 4;
+        } else {
+            umc_max = 2;
+        }
+
+        // Enable ECC reporting
+        rdmsr(MSR_IA32_MCG_CTL, regl, regh);
+        wrmsr(MSR_IA32_MCG_CTL, regl | 0x18000, regh); // DBG: X86::MSR::MCG_CTL[16:15] ?
+
+        rdmsr(MSR_AMD64_HW_CONF, regl, regh);
+        wrmsr(MSR_AMD64_HW_CONF, regl | AMD_MCA_STATUS_WR_ENABLE, regh); // // Enable Write to MCA STATUS Register
+
+        for (umc = 0; umc < umc_max; umc++)
+        {
+            rdmsr(MSR_AMD64_UMC_MCA_CTRL + (umc * AMD_UMC_OFFSET), regl, regh);
+            wrmsr(MSR_AMD64_UMC_MCA_CTRL + (umc * AMD_UMC_OFFSET), regl | 1, regh);
+        }
+
+        smn_reg = amd_smn_read(AMD_SMN_UMC_ECC_ERR_CNT_SEL);
+        amd_smn_write(AMD_SMN_UMC_ECC_ERR_CNT_SEL, smn_reg | AMD_UMC_ERR_CNT_EN); // Enable CH0 Error CNT
+
+        smn_reg = amd_smn_read(AMD_SMN_UMC_ECC_ERR_CNT_SEL + AMD_SMN_UMC_CHB_OFFSET);
+        amd_smn_write(AMD_SMN_UMC_ECC_ERR_CNT_SEL + AMD_SMN_UMC_CHB_OFFSET, smn_reg | AMD_UMC_ERR_CNT_EN); // Enable CH1 Error CNT
+    }
+#endif
+}
+
+void poll_ecc_amd_zen(void)
+{
+    uint8_t umc = 0, umc_max = 0;
+    uint32_t regh, regl;
+
+    // Number of UMC to check
+    if (imc.family == IMC_K19_VRM || imc.family == IMC_K19_RPL) {
+        umc_max = 4;
+    } else {
+        umc_max = 2;
+    }
+
+    // Check all UMCs
+    for (umc = 0; umc < umc_max; umc++)
+    {
+        // Get Status Register
+        rdmsr(MSR_AMD64_UMC_MCA_STATUS + (AMD_UMC_OFFSET * umc), regl, regh);
+
+        // Check if ECC error happened
+        if (regh & AMD_UMC_VALID_ERROR_BIT) {
+
+            // Check the type or error. Currently, we only report Corrected ECC error
+            // Uncorrected ECC errors are skipped to avoid double detection
+            if (regh & AMD_UMC_ERROR_CECC_BIT) {
+                ecc_status.type = ECC_ERR_CORRECTED;
+            } else if (regh & AMD_UMC_ERROR_UECC_BIT) {
+                ecc_status.type = ECC_ERR_UNCORRECTED;
+            } else {
+                ecc_status.type = ERR_UNKNOWN;
+            }
+
+            // Populate Channel Number
+            ecc_status.channel = umc;
+
+            // Get Core# associated with the error
+            ecc_status.core = regh & 0x3F;
+
+            // Get address
+            rdmsr(MSR_AMD64_UMC_MCA_ADDR + (AMD_UMC_OFFSET * umc), regl, regh);
+
+            ecc_status.addr = (uint64_t)(regh & 0x00FFFFFF) << 32;
+            ecc_status.addr |= regl;
+
+            // Clear Address n-th LSBs according to MSR bit[61:56]
+            ecc_status.addr &= ~0ULL << ((regh >> 24) & 0x3F);
+
+            // Get ECC Error Count
+            ecc_status.count = amd_smn_read(AMD_SMN_UMC_ECC_ERR_CNT + (AMD_SMN_UMC_CHB_OFFSET * umc)) & 0xFFFF;
+            if (!ecc_status.count) ecc_status.count++;
+
+            // Report error
+            ecc_error();
+
+            // Clear Error
+            rdmsr(MSR_AMD64_UMC_MCA_STATUS + (AMD_UMC_OFFSET * umc), regl, regh);
+            wrmsr(MSR_AMD64_UMC_MCA_STATUS + (AMD_UMC_OFFSET * umc), regl, regh & ~AMD_UMC_VALID_ERROR_BIT);
+            amd_smn_write(AMD_SMN_UMC_ECC_ERR_CNT + (AMD_SMN_UMC_CHB_OFFSET * umc), 0x0);
+
+            // Clear Internal ECC Error status
+            ecc_status.type     = ECC_ERR_NONE;
+            ecc_status.addr     = 0;
+            ecc_status.count    = 0;
+            ecc_status.core     = 0;
+            ecc_status.channel  = 0;
+        }
+    }
 }

--- a/system/imc/imc.h
+++ b/system/imc/imc.h
@@ -3,6 +3,10 @@
 #ifndef _IMC_H_
 #define _IMC_H_
 
+/**
+ * Integrated Memory Controler (IMC) Settings Detection Code
+ */
+
 /* Memory configuration Detection for AMD Zen CPUs */
 void get_imc_config_amd_zen(void);
 
@@ -20,5 +24,12 @@ void get_imc_config_intel_icl(void);
 
 /* Memory configuration Detection for Intel Alder Lake */
 void get_imc_config_intel_adl(void);
+
+/**
+ * ECC Polling Code for various IMCs
+ */
+
+/* ECC Polling Code for AMD Zen CPUs */
+void poll_ecc_amd_zen(void);
 
 #endif /* _IMC_H_ */

--- a/system/imc/imc.h
+++ b/system/imc/imc.h
@@ -30,6 +30,6 @@ void get_imc_config_intel_adl(void);
  */
 
 /* ECC Polling Code for AMD Zen CPUs */
-void poll_ecc_amd_zen(void);
+void poll_ecc_amd_zen(bool report);
 
 #endif /* _IMC_H_ */

--- a/system/memctrl.c
+++ b/system/memctrl.c
@@ -78,7 +78,7 @@ void memctrl_poll_ecc(void)
       case IMC_K19_VRM:
       case IMC_K19_RPL:
       case IMC_K19_RBT:
-        poll_ecc_amd_zen();
+        poll_ecc_amd_zen(true);
         break;
       default:
         break;

--- a/system/memctrl.c
+++ b/system/memctrl.c
@@ -14,9 +14,11 @@
 #include "memctrl.h"
 #include "imc/imc.h"
 
+#include "display.h"
+
 imc_info_t imc = {"UNDEF", 0, 0, 0, 0, 0, 0, 0, 0};
 
-ecc_info_t ecc_status = {false, ECC_ERR_NONE, 0, 0, 0, 0, 0};
+ecc_info_t ecc_status = {false, ECC_ERR_NONE, 0, 0, 0, 0};
 
 // ---------------------
 // -- Public function --
@@ -62,5 +64,23 @@ void memctrl_init(void)
     // Consistency check
     if (imc.tCL == 0 || imc.tRCD == 0 || imc.tRP == 0 || imc.tRCD == 0) {
         imc.freq = 0;
+    }
+}
+
+void memctrl_poll_ecc(void)
+{
+    if (!ecc_status.ecc_enabled) {
+        return;
+    }
+
+    switch(imc.family) {
+      case IMC_K17:
+      case IMC_K19_VRM:
+      case IMC_K19_RPL:
+      case IMC_K19_RBT:
+        poll_ecc_amd_zen();
+        break;
+      default:
+        break;
     }
 }

--- a/system/memctrl.h
+++ b/system/memctrl.h
@@ -27,17 +27,17 @@ typedef struct __attribute__((packed)) imc_infos {
 typedef enum {
     ECC_ERR_NONE,
     ECC_ERR_CORRECTED,
-    ECC_ERR_UNCORRECTED
+    ECC_ERR_UNCORRECTED,
+    ERR_UNKNOWN
 } ecc_error_type_t;
 
 typedef struct __attribute__((packed)) ecc_status {
     bool                ecc_enabled;
-    ecc_error_type_t    err_type;
-    uint64_t            err_adr;
-    uint32_t            err_col;
-    uint32_t            err_row;
-    uint32_t            err_rank;
-    uint32_t            err_bank;
+    ecc_error_type_t    type;
+    uint64_t            addr;
+    uint32_t            count;
+    uint16_t            core;
+    uint8_t             channel;
 } ecc_info_t;
 
 /**
@@ -53,5 +53,7 @@ extern imc_info_t imc;
 extern ecc_info_t ecc_status;
 
 void memctrl_init(void);
+
+void memctrl_poll_ecc(void);
 
 #endif // MEMCTRL_H

--- a/system/msr.h
+++ b/system/msr.h
@@ -8,6 +8,7 @@
  *
  *//*
  * Copyright (C) 2020-2022 Martin Whitaker.
+ * Copyright (C) 2020-2023 Sam Demeulemeester.
  */
 
 #define MSR_PLATFORM_INFO               0xce
@@ -30,6 +31,10 @@
 
 #define MSR_AMD64_NB_CFG                0xc001001f
 #define MSR_AMD64_COFVID_STATUS         0xc0010071
+#define MSR_AMD64_UMC_MCA_CTRL          0xc00020f0
+#define MSR_AMD64_UMC_MCA_STATUS        0xc00020f1
+#define MSR_AMD64_UMC_MCA_ADDR          0xc00020f2
+#define MSR_AMD64_HW_CONF               0xc0010015
 
 #define MSR_VIA_TEMP_C7                 0x1169
 #define MSR_VIA_TEMP_NANO               0x1423


### PR DESCRIPTION
Currently only available for selected AMD Zen CPUs (K17, K19 Rembrandt, K19 Raphael, K19 Vermeer).