### PR TITLE
Reduce padding and relocations

### DIFF
--- a/app/interrupt.c
+++ b/app/interrupt.c
@@ -56,7 +56,7 @@
 #define ADR_DIGITS  "8"
 #endif
 
-static const char *codes[] = {
+static const char codes[][13] = {
     "Divide by 0",
     "Debug",
     "NMI",

--- a/system/jedec_id.h
+++ b/system/jedec_id.h
@@ -10,12 +10,12 @@
 #define JEP106_CNT \
     sizeof(jep106)/sizeof(jep106[0])
 
-struct spd_jedec_manufacturer {
+struct __attribute__((packed)) spd_jedec_manufacturer {
     uint16_t jedec_code;
     char *name;
 };
 
-static const struct spd_jedec_manufacturer jep106[] = {
+static const struct __attribute__((packed)) spd_jedec_manufacturer jep106[] = {
     { 0x0001, "AMD" },
 //  { 0x0002, "AMI" },
 //  { 0x0003, "Fairchild" },

--- a/system/usbhcd.c
+++ b/system/usbhcd.c
@@ -56,7 +56,7 @@ typedef struct {
 // Private Variables
 //------------------------------------------------------------------------------
 
-static const char *hci_name[MAX_HCI_TYPE] = { "UHCI", "OHCI", "EHCI", "XHCI" };
+static const char hci_name[MAX_HCI_TYPE][5] = { "UHCI", "OHCI", "EHCI", "XHCI" };
 
 static const hcd_methods_t methods = {
     .reset_root_hub_port = NULL,

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -22,7 +22,7 @@ typedef struct {
     int             stages;
     int             iterations;
     int             errors;
-    char            *description;
+    char            description[40];
 } test_pattern_t;
 
 extern test_pattern_t test_list[NUM_TEST_PATTERNS];

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -18,7 +18,7 @@
 
 typedef struct {
     bool            enabled;
-    cpu_mode_t      cpu_mode;
+    uint8_t         cpu_mode;
     int             stages;
     int             iterations;
     int             errors;


### PR DESCRIPTION
No functional changes, just reducing / avoiding padding and avoiding costly relocations. The pointers + relocation records caused by the current version of `system/usbhcd.c` and `tests/tests.h` -> `tests/tests.c` are especially bad, considering that the strings are already manually padded to the same length. Just let them be fixed-width strings :)

```
Before/after:
   text    data     bss     dec     hex filename
 112654   26752  290816  430222   6908e build32/memtest_shared
 112036   26708  290848  429592   68e18 build32/memtest_shared

 116473   28424  294656  439553   6b501 build64/memtest_shared
 115290   27696  294624  437610   6ad6a build64/memtest_shared
```

Same motivation as #351 and #354 , higher benefit on x86-64 than on x86 this time: nearly 2 KB. Combined with these two other PRs, ~4 KB.
Tested for months on a variety of platforms through the `numa` and `simd` branches.