### PR TITLE
Add error mode for displaying bad pages

### DIFF
--- a/app/bad_pages_list.c
+++ b/app/bad_pages_list.c
@@ -1,0 +1,139 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "display.h"
+
+#include "bad_pages_list.h"
+#include "test.h"
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+#define MAX_PAGES 70
+
+//------------------------------------------------------------------------------
+// Private Variables
+//------------------------------------------------------------------------------
+
+static uintptr_t    pages[MAX_PAGES];
+static int          num_pages = 0;
+
+//------------------------------------------------------------------------------
+// Private Functions
+//------------------------------------------------------------------------------
+
+/*
+ * Check if pages already contains page
+ */
+static bool pages_contains(testword_t page)
+{
+    for (int i = 0; i < num_pages; i++) {
+        if (pages[i] == page) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * Insert page at index idx, shuffling other entries towards the end.
+ */
+static void insert_at(testword_t page, int idx)
+{
+    // Move all entries >= idx one index towards the end to make space for the new entry
+    for (int i = num_pages - 1; i >= idx; i--) {
+        pages[i + 1] = pages[i];
+    }
+
+    pages[idx] = page;
+    num_pages++;
+}
+
+/*
+ * Insert page into pages array at an index i so that pages[i-1] < pages[i]
+ * NOTE: Assumes pages is already sorted and has space
+ */
+static void insert_sorted(testword_t page)
+{
+    // Find index to insert entry into
+    int new_idx = num_pages;
+    for (int i = 0; i < num_pages; i++) {
+        if (page < pages[i]) {
+            new_idx = i;
+            break;
+        }
+    }
+
+    insert_at(page, new_idx);
+}
+
+/*
+ * 
+ */
+static int hex_string_length(uintptr_t value) {
+    int length = 0;
+    while (value != 0) {
+        length += 1;
+        value /= 0x10;
+    }
+    return length;
+}
+
+//------------------------------------------------------------------------------
+// Public Functions
+//------------------------------------------------------------------------------
+
+void bad_pages_list_init(void)
+{
+    num_pages = 0;
+
+    for (int idx = 0; idx < MAX_PAGES; idx++) {
+        pages[idx] = 0u;
+    }
+}
+
+bool bad_pages_list_insert(testword_t page)
+{
+    // If covered by existing entry we return immediately
+    if (pages_contains(page) || (num_pages + 1) > MAX_PAGES) {
+        return false;
+    }
+
+    insert_sorted(page);
+    return true;
+}
+
+void bad_pages_list_display(void)
+{
+    if (num_pages == 0) {
+        return;
+    }
+
+    check_input();
+
+    clear_message_area();
+    scroll_message_row -= 1;
+
+    int col = 0;
+    for (int i = 0; i < num_pages; i++) {
+        if (i > 0) {
+            display_scrolled_message(col, " ");
+            col++;
+        }
+
+        int hex_width = hex_string_length(pages[i]);
+        if (hex_width < 2) {
+            hex_width = 2;
+        }
+
+        int text_width = 2 + hex_width;
+        if (col + text_width > SCREEN_WIDTH) {
+            scroll();
+            col = 0;
+        }
+
+        display_scrolled_message(col, "0x%02x", pages[i]);
+        col += text_width;
+    }
+}

--- a/app/bad_pages_list.h
+++ b/app/bad_pages_list.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef BAD_PAGES_LIST_H
+#define BAD_PAGES_LIST_H
+/**
+ * \file
+ *
+ * Provides functions for displaying a list of bad pages for use with window's
+ * badmemorylist
+ *
+ *//*
+ * Copyright (C) 2020-2022 Martin Whitaker.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "test.h"
+
+/**
+ * TODO
+ */
+void bad_pages_list_init(void);
+
+/**
+ * TODO
+ */
+bool bad_pages_list_insert(testword_t page);
+
+/**
+ * TODO
+ */
+void bad_pages_list_display(void);
+
+#endif // BAD_PAGES_LIST_H

--- a/app/config.c
+++ b/app/config.c
@@ -222,6 +222,8 @@ static void parse_option(const char *option, const char *params)
             error_mode = ERROR_MODE_ADDRESS;
         } else if (strncmp(params, "badram", 7) == 0) {
             error_mode = ERROR_MODE_BADRAM;
+        } else if (strncmp(params, "badpageslist", 10) == 0) {
+            error_mode = ERROR_MODE_BADPAGESLIST;
         }
     } else if (strncmp(option, "keyboard", 9) == 0 && params != NULL) {
         if (strncmp(params, "legacy", 7) == 0) {
@@ -647,7 +649,8 @@ static void error_mode_menu(void)
     prints(POP_R+4, POP_LI, "<F2>  Error summary");
     prints(POP_R+5, POP_LI, "<F3>  Individual errors");
     prints(POP_R+6, POP_LI, "<F4>  BadRAM patterns");
-    prints(POP_R+7, POP_LI, "<F10> Exit menu");
+    prints(POP_R+7, POP_LI, "<F5>  List bad pages");
+    prints(POP_R+8, POP_LI, "<F10> Exit menu");
     printc(POP_R+3+error_mode, POP_LM, '*');
 
     bool tty_update = enable_tty;
@@ -666,6 +669,7 @@ static void error_mode_menu(void)
           case '2':
           case '3':
           case '4':
+          case '5':
             set_error_mode(ch - '1');
             break;
           case 'u':

--- a/app/config.h
+++ b/app/config.h
@@ -26,7 +26,8 @@ typedef enum {
     ERROR_MODE_NONE,
     ERROR_MODE_SUMMARY,
     ERROR_MODE_ADDRESS,
-    ERROR_MODE_BADRAM
+    ERROR_MODE_BADRAM,
+    ERROR_MODE_BADPAGESLIST,
 } error_mode_t;
 
 typedef enum {

--- a/app/error.c
+++ b/app/error.c
@@ -17,6 +17,7 @@
 #include "vmem.h"
 
 #include "badram.h"
+#include "bad_pages_list.h"
 #include "config.h"
 #include "display.h"
 #include "test.h"
@@ -160,6 +161,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
     if (new_header) {
         clear_message_area();
         badram_init();
+        bad_pages_list_init();
     }
     last_error_mode = error_mode;
 
@@ -187,6 +189,10 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
     bool new_badram = false;
     if (error_mode == ERROR_MODE_BADRAM && use_for_badram) {
         new_badram = badram_insert(page, offset);
+    }
+
+    if (error_mode == ERROR_MODE_BADPAGESLIST && use_for_badram) {
+        new_badram = bad_pages_list_insert(page);
     }
 
     if (new_address) {
@@ -306,6 +312,12 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
       case ERROR_MODE_BADRAM:
         if (new_badram) {
             badram_display();
+        }
+        break;
+
+      case ERROR_MODE_BADPAGESLIST:
+        if (new_badram) {
+            bad_pages_list_display();
         }
         break;
 

--- a/app/main.c
+++ b/app/main.c
@@ -42,6 +42,7 @@
 #include "unistd.h"
 
 #include "badram.h"
+#include "bad_pages_list.h"
 #include "config.h"
 #include "display.h"
 #include "error.h"
@@ -233,6 +234,7 @@ static void global_init(void)
     smbios_init();
 
     badram_init();
+    bad_pages_list_init();
 
     config_init();
 
@@ -566,6 +568,7 @@ void main(void)
                 if (!dummy_run) {
                     display_start_run();
                     badram_init();
+                    bad_pages_list_init();
                     error_init();
                 }
             }

--- a/build32/Makefile
+++ b/build32/Makefile
@@ -75,6 +75,7 @@ TST_OBJS = tests/addr_walk1.o \
            tests/tests.o
 
 APP_OBJS = app/badram.o \
+           app/bad_pages_list.o \
            app/config.o \
            app/display.o \
            app/error.o \

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -74,6 +74,7 @@ TST_OBJS = tests/addr_walk1.o \
            tests/tests.o
 
 APP_OBJS = app/badram.o \
+           app/bad_pages_list.o \
            app/config.o \
            app/display.o \
            app/error.o \


### PR DESCRIPTION
Main motivation for this patch is to be able to block bad pages on windows with it's bcdedit utility.

Since windows wants page numbers and not rages I opted to try and fit as many on screen as I could.

So it's just a list of bad pages:
![screenshot of memtest86plus in list bad pages error mode](https://github.com/memtest86plus/memtest86plus/assets/29005635/cd64763a-c59e-459f-9d48-f91c399b1a4e)

Max is 70 since each of the 14 lines can hold 5 max length addresses.

