### PR TITLE
Add boot options to perform display rotation and set preferred screen resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ recognised:
       * usb
       * both
   * screen.mode=*w*x*h* (EFI framebuffer only)
-    * where *w*x*h* is the preferred screen reolution (e.g. 1024x768)
+    * where *w*x*h* is the preferred screen resolution (e.g. 1024x768)
   * screen.mode=bios (EFI framebuffer only)
     * uses the default screen resolution set by the UEFI BIOS
   * screen.rhs-up (graphics mode only)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ recognised:
       * legacy
       * usb
       * both
+  * screen.mode=*w*x*h* (EFI framebuffer only)
+    * where *w*x*h* is the preferred screen reolution (e.g. 1024x768)
+  * screen.mode=bios (EFI framebuffer only)
+    * uses the default screen resolution set by the UEFI BIOS
+  * screen.rhs-up (graphics mode only)
+    * rotates the display clockwise by 90 degrees
+  * screen.lhs-up (graphics mode only)
+    * rotates the display anti-clockwiseby 90 degrees
+  * efidebug
+    * displays information about the EFI framebuffer
   * usbdebug
     * pauses after probing for USB keyboards
   * usbinit=*mode*
@@ -199,6 +209,29 @@ workarounds provided by the "usbinit" boot option.
 **NOTE**: Hot-plugging is not currently supported by the Memtest86+ USB
 drivers. When using these, your USB keyboard should be plugged in before
 running Memtest86+ and should remain plugged in throughout the test.
+
+## Display Rotation
+
+Some 2-in-1 machines use an LCD panel which is natively a portrait mode
+display but is mounted on its side when attached to the keyboard. When
+using the display in graphics mode, Memtest86+ can rotate its display
+to match. Add either the "screen.rhs-up" or the "screen.lhs-up" option
+on the boot command line, depending on the orientation of the LCD panel.
+When using the display in text mode, it is expected that the BIOS will
+take care of this automatically.
+
+## Screen Resolution
+
+When booted in legacy mode, Memtest86+ will use the screen resolution that
+has been set by the BIOS or by the intermediate bootloader. When booted in
+UEFI mode, Memtest86+ will normally select the smallest available screen
+resolution that encompasses its 640x400 pixel display. Some BIOSs return
+incorrect information about the available display modes, so you can
+override this by adding the "screen.mode=" option on the boot command
+line.
+
+Note that when using display rotation, the specified screen resolution is
+for the unrotated display.
 
 ## Operation
 

--- a/boot/efisetup.c
+++ b/boot/efisetup.c
@@ -344,6 +344,17 @@ static efi_status_t set_screen_info_from_gop(screen_info_t *si, efi_handle_t *ha
 
     bool use_current_mode = (pref_h_resolution == 0) && (pref_v_resolution == 0);
 
+#if DEBUG
+    print_string("Requested size : ");
+    print_dec(pref_h_resolution);
+    print_string(" x ");
+    print_dec(pref_v_resolution);
+    if (rotate) {
+        print_string(" rotated");
+    }
+    print_string("\n");
+#endif
+
     efi_gop_mode_info_t best_info;
     best_info.h_resolution = UINT32_MAX;
     best_info.v_resolution = UINT32_MAX;

--- a/boot/efisetup.c
+++ b/boot/efisetup.c
@@ -153,22 +153,22 @@ static void test_frame_buffer(screen_info_t *si)
 #endif
 
     uint8_t *lfb_row = (uint8_t *)lfb_base;
-    for (int y = 0; y < 8; y++) {
+    for (int y = 0; y < 4; y++) {
         for (int x = 0; x < si->lfb_width; x++) {
             for (int b = 0; b < pixel_size; b++) {
                 lfb_row[x * pixel_size + b] = pixel_value.byte[b];
             }
         }
-        lfb_row += si->lfb_linelength;
+        lfb_row += si->lfb_linelength * 2;
     }
     lfb_row += (si->lfb_height - 16) * si->lfb_linelength;
-    for (int y = 0; y < 8; y++) {
+    for (int y = 0; y < 4; y++) {
         for (int x = 0; x < si->lfb_width; x++) {
             for (int b = 0; b < pixel_size; b++) {
                 lfb_row[x * pixel_size + b] = pixel_value.byte[b];
             }
         }
-        lfb_row += si->lfb_linelength;
+        lfb_row += si->lfb_linelength * 2;
     }
 }
 

--- a/system/screen.c
+++ b/system/screen.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2020-2022 Martin Whitaker
+// Copyright (C) 2020-2024 Martin Whitaker
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -9,6 +9,8 @@
 
 #include "font.h"
 #include "vmem.h"
+
+#include "string.h"
 
 #include "screen.h"
 
@@ -50,6 +52,7 @@ static int lfb_bytes_per_pixel = 0;
 
 static uintptr_t lfb_base;
 static uintptr_t lfb_stride;
+static bool      lfb_rotate;
 
 static uint32_t lfb_pallete[16];
 
@@ -77,15 +80,28 @@ static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
     uint8_t fg_colour = attr % 16;
     uint8_t bg_colour = attr / 16;
 
-    uint8_t *pixel_row = (uint8_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
-    for (int y = 0; y < FONT_HEIGHT; y++) {
-        uint8_t font_row = font_data[ch][y];
-        for (int x = 0; x < FONT_WIDTH; x++) {
-            pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
-            font_row <<= 1;
+    if (lfb_rotate) {
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                uint8_t *pixel = (uint8_t *)lfb_base
+                               + (col * FONT_WIDTH + x) * lfb_stride
+                               + (SCREEN_HEIGHT - row) * FONT_HEIGHT - y - 1;
+                *pixel = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
         }
-        pixel_row += lfb_stride;
-    }
+    } else {
+        uint8_t *pixel_row = (uint8_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
+            pixel_row += lfb_stride;
+        }
+   }
 }
 
 static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
@@ -96,14 +112,27 @@ static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
     uint16_t fg_colour = lfb_pallete[attr % 16];
     uint16_t bg_colour = lfb_pallete[attr / 16];
 
-    uint16_t *pixel_row = (uint16_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
-    for (int y = 0; y < FONT_HEIGHT; y++) {
-        uint8_t font_row = font_data[ch][y];
-        for (int x = 0; x < FONT_WIDTH; x++) {
-            pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
-            font_row <<= 1;
+    if (lfb_rotate) {
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                uint16_t *pixel = (uint16_t *)lfb_base
+                                + (col * FONT_WIDTH + x) * lfb_stride
+                                + (SCREEN_HEIGHT - row) * FONT_HEIGHT - y - 1;
+                *pixel = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
         }
-        pixel_row += lfb_stride;
+    } else {
+        uint16_t *pixel_row = (uint16_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
+            pixel_row += lfb_stride;
+        }
     }
 }
 
@@ -115,17 +144,33 @@ static void lfb24_put_char(int row, int col, uint8_t ch, uint8_t attr)
     uint32_t fg_colour = lfb_pallete[attr % 16];
     uint32_t bg_colour = lfb_pallete[attr / 16];
 
-    uint8_t *pixel_row = (uint8_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH * 3;
-    for (int y = 0; y < FONT_HEIGHT; y++) {
-        uint8_t font_row = font_data[ch][y];
-        for (int x = 0; x < FONT_WIDTH * 3; x += 3) {
-            uint32_t colour = font_row & 0x80 ? fg_colour : bg_colour;
-            pixel_row[x+0] = colour & 0xff; colour >>= 8;
-            pixel_row[x+1] = colour & 0xff; colour >>= 8;
-            pixel_row[x+2] = colour & 0xff;
-            font_row <<= 1;
+    if (lfb_rotate) {
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                uint8_t *pixel = (uint8_t *)lfb_base
+                               + (col * FONT_WIDTH + x) * lfb_stride
+                               + ((SCREEN_HEIGHT - row) * FONT_HEIGHT - y - 1) * 3;
+                uint32_t colour = font_row & 0x80 ? fg_colour : bg_colour;
+                pixel[0] = colour & 0xff; colour >>= 8;
+                pixel[1] = colour & 0xff; colour >>= 8;
+                pixel[2] = colour & 0xff;
+                font_row <<= 1;
+            }
         }
-        pixel_row += lfb_stride;
+    } else {
+        uint8_t *pixel_row = (uint8_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH * 3;
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH * 3; x += 3) {
+                uint32_t colour = font_row & 0x80 ? fg_colour : bg_colour;
+                pixel_row[x+0] = colour & 0xff; colour >>= 8;
+                pixel_row[x+1] = colour & 0xff; colour >>= 8;
+                pixel_row[x+2] = colour & 0xff;
+                font_row <<= 1;
+            }
+            pixel_row += lfb_stride;
+        }
     }
 }
 
@@ -137,14 +182,27 @@ static void lfb32_put_char(int row, int col, uint8_t ch, uint8_t attr)
     uint32_t fg_colour = lfb_pallete[attr % 16];
     uint32_t bg_colour = lfb_pallete[attr / 16];
 
-    uint32_t *pixel_row = (uint32_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
-    for (int y = 0; y < FONT_HEIGHT; y++) {
-        uint8_t font_row = font_data[ch][y];
-        for (int x = 0; x < FONT_WIDTH; x++) {
-            pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
-            font_row <<= 1;
+    if (lfb_rotate) {
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                uint32_t *pixel = (uint32_t *)lfb_base
+                                + (col * FONT_WIDTH + x) * lfb_stride
+                                + (SCREEN_HEIGHT - row) * FONT_HEIGHT - y - 1;
+                *pixel = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
         }
-        pixel_row += lfb_stride;
+    } else {
+        uint32_t *pixel_row = (uint32_t *)lfb_base + row * FONT_HEIGHT * lfb_stride + col * FONT_WIDTH;
+        for (int y = 0; y < FONT_HEIGHT; y++) {
+            uint8_t font_row = font_data[ch][y];
+            for (int x = 0; x < FONT_WIDTH; x++) {
+                pixel_row[x] = font_row & 0x80 ? fg_colour : bg_colour;
+                font_row <<= 1;
+            }
+            pixel_row += lfb_stride;
+        }
     }
 }
 
@@ -155,9 +213,39 @@ static void put_value(int row, int col, uint16_t value)
     put_char(row, col, value % 256, value / 256);
 }
 
+static bool option_is_rotate(const char *option, int option_length)
+{
+    return (option_length == 6) && (strncmp(option, "rotate", 6) == 0);
+}
+
 //------------------------------------------------------------------------------
 // Public Functions
 //------------------------------------------------------------------------------
+
+bool check_for_rotate_option(uintptr_t cmd_line_addr, int cmd_line_size)
+{
+    if (cmd_line_addr != 0) {
+        if (cmd_line_size == 0) cmd_line_size = 255;
+        const char *cmd_line = (const char *)cmd_line_addr;
+        const char *option = cmd_line;
+        int option_length = 0;
+        for (int i = 0; i < cmd_line_size; i++) {
+            switch (cmd_line[i]) {
+              case '\0':
+                return option_is_rotate(option, option_length);
+              case ' ':
+                if (option_is_rotate(option, option_length)) return true;
+                option = &cmd_line[i+1];
+                option_length = 0;
+                break;
+              default:
+                option_length++;
+                break;
+            }
+        }
+    }
+    return false;
+}
 
 void screen_init(void)
 {
@@ -218,13 +306,25 @@ void screen_init(void)
             line += lfb_stride / sizeof(uint32_t);
         }
 
-        int excess_width = lfb_width - (SCREEN_WIDTH * FONT_WIDTH);
-        if (excess_width > 0) {
-            lfb_base += (excess_width / 2) * lfb_bytes_per_pixel;
-        }
-        int excess_height = lfb_height - (SCREEN_HEIGHT * FONT_HEIGHT);
-        if (excess_height > 0) {
-            lfb_base += (excess_height / 2) * lfb_stride;
+        lfb_rotate = check_for_rotate_option(boot_params->cmd_line_ptr, boot_params->cmd_line_size);
+        if (lfb_rotate) {
+            int excess_width = lfb_width - (SCREEN_HEIGHT * FONT_HEIGHT);
+            if (excess_width > 0) {
+                lfb_base += (excess_width / 2) * lfb_bytes_per_pixel;
+            }
+            int excess_height = lfb_height - (SCREEN_WIDTH * FONT_WIDTH);
+            if (excess_height > 0) {
+                lfb_base += (excess_height / 2) * lfb_stride;
+            }
+        } else {
+            int excess_width = lfb_width - (SCREEN_WIDTH * FONT_WIDTH);
+            if (excess_width > 0) {
+                lfb_base += (excess_width / 2) * lfb_bytes_per_pixel;
+            }
+            int excess_height = lfb_height - (SCREEN_HEIGHT * FONT_HEIGHT);
+            if (excess_height > 0) {
+                lfb_base += (excess_height / 2) * lfb_stride;
+            }
         }
 
         if (lfb_bytes_per_pixel != 3) {

--- a/system/screen.h
+++ b/system/screen.h
@@ -8,9 +8,10 @@
  * display.
  *
  *//*
- * Copyright (C) 2020-2022 Martin Whitaker.
+ * Copyright (C) 2020-2024 Martin Whitaker.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -56,6 +57,11 @@ extern vga_buffer_t shadow_buffer;
  * Has no effect on background colours.
  */
 #define BOLD        8
+
+/*
+ * Return true if the 'rotate' option is present on the boot command line.
+ */
+bool check_for_rotate_option(uintptr_t cmd_line_addr, int cmd_line_size);
 
 /**
  * Initialise the display interface.

--- a/system/screen.h
+++ b/system/screen.h
@@ -11,7 +11,6 @@
  * Copyright (C) 2020-2024 Martin Whitaker.
  */
 
-#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -57,15 +56,6 @@ extern vga_buffer_t shadow_buffer;
  * Has no effect on background colours.
  */
 #define BOLD        8
-
-/*
- * Scans the given command line for screen options. If screen.mode
- * is found, returns the width and height (in pixels) in w and h
- * or 0 and 0 for the special case of "bios", otherwise leaves
- * them unchanged. If screen.rhs-up or screen.lhs-up is found,
- * returns true in rotate, otherwise returns false.
- */
-void get_screen_options(uint32_t cmd_line_ptr, uint32_t cmd_line_size, uint32_t *w, uint32_t *h, bool *rotate);
 
 /**
  * Initialise the display interface.

--- a/system/screen.h
+++ b/system/screen.h
@@ -59,9 +59,13 @@ extern vga_buffer_t shadow_buffer;
 #define BOLD        8
 
 /*
- * Return true if the 'rotate' option is present on the boot command line.
+ * Scans the given command line for screen options. If screen.mode
+ * is found, returns the width and height (in pixels) in w and h
+ * or 0 and 0 for the special case of "bios", otherwise leaves
+ * them unchanged. If screen.rhs-up or screen.lhs-up is found,
+ * returns true in rotate, otherwise returns false.
  */
-bool check_for_rotate_option(uintptr_t cmd_line_addr, int cmd_line_size);
+void get_screen_options(uint32_t cmd_line_ptr, uint32_t cmd_line_size, uint32_t *w, uint32_t *h, bool *rotate);
 
 /**
  * Initialise the display interface.


### PR DESCRIPTION
This addresses issue #381. It's not a perfect fix for that machine, due to a buggy BIOS, but hopefully it will be useful for other 2-in-1 laptops too.

As I needed to add boot command line parsing in the efisetup code, I've taken the opportunity to make the EFI debug code a run-time option instead of a compile-time option.