### PR TITLE
Clang build fixes

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -171,7 +171,8 @@ static void run_at(uintptr_t addr, int my_cpu)
     __asm__ __volatile__("movl %0, %%edi" : : "r" (new_start_addr));
 #endif
 
-    goto *new_start_addr;
+    // Jump to new_start_addr.
+    ((void (*)(void))new_start_addr)();
 }
 
 static bool set_load_addr(uintptr_t *load_addr, size_t program_size, uintptr_t lower_limit, uintptr_t upper_limit)

--- a/boot/x86/startup32.S
+++ b/boot/x86/startup32.S
@@ -648,18 +648,37 @@ gdt_end:
 
 	.data
 
-	.macro	ptes64 start, count=64
-	.quad	\start + 0x0000000 + 0x83
-	.quad	\start + 0x0200000 + 0x83
-	.quad	\start + 0x0400000 + 0x83
-	.quad	\start + 0x0600000 + 0x83
-	.quad	\start + 0x0800000 + 0x83
-	.quad	\start + 0x0A00000 + 0x83
-	.quad	\start + 0x0C00000 + 0x83
-	.quad	\start + 0x0E00000 + 0x83
-	.if \count-1
-	ptes64	"(\start+0x01000000)",\count-1
-	.endif
+	.macro	ptes8 start, flags
+	.quad	\start + 0x00000000 + \flags
+	.quad	\start + 0x00200000 + \flags
+	.quad	\start + 0x00400000 + \flags
+	.quad	\start + 0x00600000 + \flags
+	.quad	\start + 0x00800000 + \flags
+	.quad	\start + 0x00A00000 + \flags
+	.quad	\start + 0x00C00000 + \flags
+	.quad	\start + 0x00E00000 + \flags
+	.endm
+
+	.macro	ptes64 start, flags
+	ptes8	\start + 0x00000000, \flags
+	ptes8	\start + 0x01000000, \flags
+	ptes8	\start + 0x02000000, \flags
+	ptes8	\start + 0x03000000, \flags
+	ptes8	\start + 0x04000000, \flags
+	ptes8	\start + 0x05000000, \flags
+	ptes8	\start + 0x06000000, \flags
+	ptes8	\start + 0x07000000, \flags
+	.endm
+
+	.macro	ptes512 start, flags
+	ptes64	\start + 0x00000000, \flags
+	ptes64	\start + 0x08000000, \flags
+	ptes64	\start + 0x10000000, \flags
+	ptes64	\start + 0x18000000, \flags
+	ptes64	\start + 0x20000000, \flags
+	ptes64	\start + 0x28000000, \flags
+	ptes64	\start + 0x30000000, \flags
+	ptes64	\start + 0x38000000, \flags
 	.endm
 
 	.macro	maxdepth depth=1
@@ -702,22 +721,22 @@ pdp:
 	.align	4096
 	.globl	pd0
 pd0:
-	ptes64	0x0000000000000000
+	ptes512	0x0000000000000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd1
 pd1:
-	ptes64	0x0000000040000000
+	ptes512	0x0000000040000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd2
 pd2:
-	ptes64	0x0000000080000000
+	ptes512	0x0000000080000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd3
 pd3:
-	ptes64	0x00000000C0000000
+	ptes512	0x00000000C0000000, 0x0000000000000083
 
 	.previous
 

--- a/boot/x86/startup64.S
+++ b/boot/x86/startup64.S
@@ -473,18 +473,37 @@ gdt_end:
 
 	.data
 
-	.macro	ptes64 start, count=64
-	.quad	\start + 0x0000000 + 0x83
-	.quad	\start + 0x0200000 + 0x83
-	.quad	\start + 0x0400000 + 0x83
-	.quad	\start + 0x0600000 + 0x83
-	.quad	\start + 0x0800000 + 0x83
-	.quad	\start + 0x0A00000 + 0x83
-	.quad	\start + 0x0C00000 + 0x83
-	.quad	\start + 0x0E00000 + 0x83
-	.if \count-1
-	ptes64	"(\start+0x01000000)",\count-1
-	.endif
+	.macro	ptes8 start, flags
+	.quad	\start + 0x00000000 + \flags
+	.quad	\start + 0x00200000 + \flags
+	.quad	\start + 0x00400000 + \flags
+	.quad	\start + 0x00600000 + \flags
+	.quad	\start + 0x00800000 + \flags
+	.quad	\start + 0x00A00000 + \flags
+	.quad	\start + 0x00C00000 + \flags
+	.quad	\start + 0x00E00000 + \flags
+	.endm
+
+	.macro	ptes64 start, flags
+	ptes8	\start + 0x00000000, \flags
+	ptes8	\start + 0x01000000, \flags
+	ptes8	\start + 0x02000000, \flags
+	ptes8	\start + 0x03000000, \flags
+	ptes8	\start + 0x04000000, \flags
+	ptes8	\start + 0x05000000, \flags
+	ptes8	\start + 0x06000000, \flags
+	ptes8	\start + 0x07000000, \flags
+	.endm
+
+	.macro	ptes512 start, flags
+	ptes64	\start + 0x00000000, \flags
+	ptes64	\start + 0x08000000, \flags
+	ptes64	\start + 0x10000000, \flags
+	ptes64	\start + 0x18000000, \flags
+	ptes64	\start + 0x20000000, \flags
+	ptes64	\start + 0x28000000, \flags
+	ptes64	\start + 0x30000000, \flags
+	ptes64	\start + 0x38000000, \flags
 	.endm
 
 	.macro	maxdepth depth=1
@@ -522,22 +541,22 @@ pdp:
 	.align	4096
 	.globl	pd0
 pd0:
-	ptes64	0x0000000000000000
+	ptes512	0x0000000000000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd1
 pd1:
-	ptes64	0x0000000040000000
+	ptes512	0x0000000040000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd2
 pd2:
-	ptes64	0x0000000080000000
+	ptes512	0x0000000080000000, 0x0000000000000083
 
 	.align	4096
 	.globl	pd3
 pd3:
-	ptes64	0x00000000C0000000
+	ptes512	0x00000000C0000000, 0x0000000000000083
 
 	.previous
 

--- a/build/i586/Makefile
+++ b/build/i586/Makefile
@@ -1,8 +1,9 @@
-AS = as -32
-CC = gcc
-OBJCOPY = objcopy
+AS ?= as -32
+CC ?= gcc
+LD ?= ld
+OBJCOPY ?= objcopy
 
-GIT = git
+GIT ?= git
 
 ifeq ($(GIT),none)
   GIT_AVAILABLE = false
@@ -168,7 +169,7 @@ FORCE:
 # then link it dynamically so I have full relocation information.
 
 memtest_shared: $(OBJS) $(MS_LDS) Makefile
-	$(LD) --warn-constructors --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
+	$(LD) --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
 	$(LD) -shared -Bsymbolic -T $(MS_LDS) -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared

--- a/build/i586/ldscripts/memtest_efi.lds
+++ b/build/i586/ldscripts/memtest_efi.lds
@@ -32,6 +32,7 @@ SECTIONS {
 		. = ALIGN(512);
 		_file_sbat_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_real_text_size  = _real_text_end  - _file_text_start;

--- a/build/i586/ldscripts/memtest_mbr.lds
+++ b/build/i586/ldscripts/memtest_mbr.lds
@@ -12,6 +12,7 @@ SECTIONS {
 		*(.data)
 		_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_sys_size = (_end - _start + 15) >> 4;

--- a/build/i586/ldscripts/memtest_shared.lds
+++ b/build/i586/ldscripts/memtest_shared.lds
@@ -20,6 +20,7 @@ SECTIONS {
 	.hash       : { *(.hash) }
 	.gnu.hash   : { *(.gnu.hash) }
 	.dynamic    : { *(.dynamic) }
+	.shstrtab   : { *(.shstrtab) }
 
 	.rel.text    : { *(.rel.text   .rel.text.*) }
 	.rel.rodata  : { *(.rel.rodata .rel.rodata.*) }

--- a/build/loongarch64/Makefile
+++ b/build/loongarch64/Makefile
@@ -170,7 +170,7 @@ FORCE:
 # then link it dynamically so I have full relocation information.
 
 memtest_shared: $(OBJS) $(MS_LDS) Makefile
-	$(LD) --warn-constructors --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
+	$(LD) --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
 	$(LD) -shared -Bsymbolic -T $(MS_LDS) -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared

--- a/build/loongarch64/ldscripts/memtest_efi.lds
+++ b/build/loongarch64/ldscripts/memtest_efi.lds
@@ -29,6 +29,7 @@ SECTIONS {
 		. = ALIGN(512);
 		_file_sbat_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_real_text_size  = _real_text_end  - _file_text_start;

--- a/build/loongarch64/ldscripts/memtest_shared.lds
+++ b/build/loongarch64/ldscripts/memtest_shared.lds
@@ -20,6 +20,7 @@ SECTIONS {
 	.hash       : { *(.hash) }
 	.gnu.hash   : { *(.gnu.hash) }
 	.dynamic    : { *(.dynamic) }
+	.shstrtab   : { *(.shstrtab) }
 
 	.rela.text    : { *(.rela.text   .rela.text.*) }
 	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) }

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -1,8 +1,9 @@
-AS = as -64
-CC = gcc
-OBJCOPY = objcopy
+AS ?= as -64
+CC ?= gcc
+LD ?= ld
+OBJCOPY ?= objcopy
 
-GIT = git
+GIT ?= git
 
 ifeq ($(GIT),none)
   GIT_AVAILABLE = false
@@ -167,7 +168,7 @@ FORCE:
 # then link it dynamically so I have full relocation information.
 
 memtest_shared: $(OBJS) $(MS_LDS) Makefile
-	$(LD) --warn-constructors --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
+	$(LD) --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
 	$(LD) -shared -Bsymbolic -T $(MS_LDS) -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared

--- a/build/x86_64/ldscripts/memtest_efi.lds
+++ b/build/x86_64/ldscripts/memtest_efi.lds
@@ -32,6 +32,7 @@ SECTIONS {
 		. = ALIGN(512);
 		_file_sbat_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_real_text_size  = _real_text_end  - _file_text_start;

--- a/build/x86_64/ldscripts/memtest_mbr.lds
+++ b/build/x86_64/ldscripts/memtest_mbr.lds
@@ -12,6 +12,7 @@ SECTIONS {
 		*(.data)
 		_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_sys_size = (_end - _start + 15) >> 4;

--- a/build/x86_64/ldscripts/memtest_shared.lds
+++ b/build/x86_64/ldscripts/memtest_shared.lds
@@ -20,12 +20,14 @@ SECTIONS {
 	.hash       : { *(.hash) }
 	.gnu.hash   : { *(.gnu.hash) }
 	.dynamic    : { *(.dynamic) }
+	.shstrtab   : { *(.shstrtab) }
 
 	.rela.text    : { *(.rela.text   .rela.text.*) }
 	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) }
 	.rela.data    : { *(.rela.data   .rela.data.*) }
 	.rela.got     : { *(.rela.got    .rela.got.*) }
 	.rela.plt     : { *(.rela.plt    .rela.plt.*) }
+	.rela.dyn     : { *(.rela.dyn    .rela.dyn.*) }
 
 	. = ALIGN(4);
 	.data : {

--- a/lib/string.c
+++ b/lib/string.c
@@ -53,7 +53,7 @@ void *memmove(void *dest, const void *src, size_t n)
     return dest;
 }
 
-#if (defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if (defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__clang__))
 
 void *memcpy (void *dest, const void *src, size_t len)
 {

--- a/lib/string.h
+++ b/lib/string.h
@@ -36,7 +36,7 @@ static inline int memcmp(const void *s1, const void *s2, size_t n)
  * not overlap.
  * void *memcpy(void *dst, const void *src, size_t n);
  */
-#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__clang__))
     #define memcpy(d, s, n) __builtin_memcpy((d), (s), (n))
 #else
     void *memcpy (void *dest, const void *src, size_t len);
@@ -54,7 +54,7 @@ void *memmove(void *dest, const void *src, size_t n);
  * value c.
  * void *memset(void *s, int c, size_t n);
  */
-#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__clang__))
     #define memset(s, c, n) __builtin_memset((s), (c), (n))
 #else
     void *memset (void *dest, int val, size_t len);


### PR DESCRIPTION
It happens that only a couple tweaks are necessary to make it possible to *compile* and *assemble* the current memtest86+ code. Therefore, I think we should integrate such changes, so as to be able to benefit from Clang's warnings, at least one of which ( #361 ) is demonstrably useful.
Making Clang able to *link* memtest86+ requires an additional tweak, because Clang's `__builtin_memcpy()` and `__builtin_memset()` do, in this case, end up calling `memcpy()` and `memset()`, which we have been able to stop providing by default thanks to GCC's builtins, except for the GDB debugging build.

There are obvious workarounds, either by handling `__clang__` the same way as `DEBUG_GDB`, or by providing an inline version of those two functions:
```
diff --git a/lib/string.h b/lib/string.h
index fea0b3b..da1b15e 100644
--- a/lib/string.h
+++ b/lib/string.h
@@ -37,7 +37,18 @@ static inline int memcmp(const void *s1, const void *s2, size_t n)
  * void *memcpy(void *dst, const void *src, size_t n);
  */
 #ifndef DEBUG_GDB
-    #define memcpy(d, s, n) __builtin_memcpy((d), (s), (n))
+    #ifdef __clang__
+        static inline void *memcpy (void *dest, const void *src, size_t len)
+        {
+            char *d = dest;
+            const char *s = src;
+            while (len--)
+                *d++ = *s++;
+            return dest;
+        }
+    #else
+        #define memcpy(d, s, n) __builtin_memcpy((d), (s), (n))
+    #endif
 #else
     void *memcpy (void *dest, const void *src, size_t len);
 #endif
@@ -55,7 +66,17 @@ void *memmove(void *dest, const void *src, size_t n);
  * void *memset(void *s, int c, size_t n);
  */
 #ifndef DEBUG_GDB
-    #define memset(s, c, n) __builtin_memset((s), (c), (n))
+    #ifdef __clang__
+        static inline void *memset (void *dest, int val, size_t len)
+        {
+            unsigned char *ptr = dest;
+            while (len-- > 0)
+                *ptr++ = val;
+            return dest;
+        }
+    #else
+        #define memset(s, c, n) __builtin_memset((s), (c), (n))
+    #endif
 #else
     void *memset (void *dest, int val, size_t len);
 #endif
```