### PR TITLE
Add GPT partition support

### DIFF
--- a/build32/Makefile
+++ b/build32/Makefile
@@ -228,7 +228,7 @@ GRUB_LIB_DIR ?= /usr/lib/grub
 
 GRUB_MKIMAGE := $(shell command -v grub2-mkimage || command -v grub-mkimage)
 
-GRUB_MODULES = iso9660 fat part_msdos all_video font gfxterm gfxmenu \
+GRUB_MODULES = iso9660 fat part_msdos part_gpt all_video font gfxterm gfxmenu \
                boot chain configfile echo ls
 
 grub-eltorito.img:

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -227,7 +227,7 @@ GRUB_LIB_DIR ?= /usr/lib/grub
 
 GRUB_MKIMAGE := $(shell command -v grub2-mkimage || command -v grub-mkimage)
 
-GRUB_MODULES = iso9660 fat part_msdos all_video font gfxterm gfxmenu \
+GRUB_MODULES = iso9660 fat part_msdos part_gpt all_video font gfxterm gfxmenu \
                boot chain configfile echo ls
 
 grub-eltorito.img:


### PR DESCRIPTION
People creating the media through [_File System Transposition_](https://lists.gnu.org/archive/html/grub-devel/2022-06/msg00024.html) rather than DD copy may end up with a media that uses a GPT partition table rather than MBR.

So add GPT support to GRUB, as a low cost beneficial change.

For reference, _File System Transposition_ is the default method used by Rufus and other utilities for creating bootable media from an ISO, and it allows users to select GPT instead over MBR, in which case `memtest86+` will not boot.