### PR TITLE
Correct check for console "ttyS..." parameter

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -152,7 +152,7 @@ static void parse_serial_params(const char *params)
     }
 
     // No TTY port passed, use default ttyS0
-    if (strncmp(params, "ttyS", 5) == 0) {
+    if (strncmp(params, "ttyS", 4) != 0) {
         return;
     }
 


### PR DESCRIPTION
I think this was just a typo in commit 2e048a7c, and that the intention is to return early unless the string starts with "ttyS". The only way the old code would return is if the string is exactly "ttyS", and with any other string it would carry on to try read out a port number and speed.