### PR TITLE
efisetup: Ignore Unicode byte-order mark in command line

### DIFF
--- a/boot/efisetup.c
+++ b/boot/efisetup.c
@@ -179,6 +179,11 @@ static int get_cmd_line_length(efi_loaded_image_t *image)
     efi_char16_t *cmd_line = (efi_char16_t *)image->load_options;
     int max_length = image->load_options_size / sizeof(efi_char16_t);
     int length = 0;
+    // Skip Unicode byte order mark if present
+    if (cmd_line[0] == u'\uFEFF') {
+        cmd_line = &cmd_line[1];
+        max_length--;
+    }
     while (length < max_length && cmd_line[length] > 0x00 && cmd_line[length] < 0x80) {
         length++;
     }
@@ -188,6 +193,9 @@ static int get_cmd_line_length(efi_loaded_image_t *image)
 static void get_cmd_line(efi_loaded_image_t *image, int num_chars, char *buffer)
 {
     efi_char16_t *cmd_line = (efi_char16_t *)image->load_options;
+    if (cmd_line[0] == u'\uFEFF') {
+        cmd_line = &cmd_line[1];
+    }
     for (int i = 0; i < num_chars; i++) {
         buffer[i] = cmd_line[i];
     }

--- a/doc/HOW_TO_DEBUG_WITH_GDB.md
+++ b/doc/HOW_TO_DEBUG_WITH_GDB.md
@@ -46,6 +46,11 @@ and confirm with Enter.
 The directory "\EFI\boot" and the file "BOOT_X64.efi" are automatically
 created by the debug-script.
 
+You can add memtest command line parameters as "optional data" to the boot entry created above, e.g. for `usbdebug`:
+		`bcfg boot -opt 0x0 ^"usbdebug^"`
+Note the UEFI-shell escaped quotes. Alternatively you can create a UTF-16 file with the parameters, e.g. with `edit params.txt` and add its contents:
+		`bcfg boot -opt 0x0 FS0:\params.txt`
+
 When you run the script the next time, memtest.efi should run without
 previous user interaction.
 


### PR DESCRIPTION
References #418

The Unicode command line  can have a Unicode BOM:
https://wiki.archlinux.org/title/EFISTUB#bcfg
