### PR TITLE
Change SPD math from floating point to integer (fixed point)

### DIFF
--- a/lib/macros.h
+++ b/lib/macros.h
@@ -20,9 +20,23 @@
 #define __same_type(a, b)    __builtin_types_compatible_p(typeof(a), typeof(b))
 #define __must_be_array(a)   BUILD_BUG_ON_ZERO(__same_type((a), &(a)[0]))
 #define ARRAY_SIZE(arr)      (sizeof(arr) / sizeof((arr)[0]) + __must_be_array(arr))
+
+#define min(x, y) ({                        \
+    typeof(x) _min1 = (x);                  \
+    typeof(y) _min2 = (y);                  \
+    (void) (&_min1 == &_min2);              \
+    _min1 < _min2 ? _min1 : _min2; })
+
+#define max(x, y) ({                        \
+    typeof(x) _max1 = (x);                  \
+    typeof(y) _max2 = (y);                  \
+    (void) (&_max1 == &_max2);              \
+    _max1 > _max2 ? _max1 : _max2; })
 #else
 // Fallback definitions.
 #define ARRAY_SIZE(var_) (sizeof(var_) / sizeof((var_)[0]))
+#define min(x, y) (x < y ? x : y)
+#define max(x, y) (x > y ? x : y)
 #endif
 
 #endif


### PR DESCRIPTION
There is really no need to use floating point for calculating freq and timings since there are no floats in the spd_infos struct. Doing so reduces the code size and protects us from bugs like the one discovered in https://github.com/memtest86plus/memtest86plus/issues/425.

Summary of the changes:
 - introduce ceildiv() function to perform int division with ceiling.

 - ddr5: trivial fix, spdi->freq can be easily calculated without floats just by changin the order of operations.

 - ddr4: calculate tCK/tns as 10^-3 (mili) int. Use ceildiv() instead of adding ROUNDING_FACTOR. Simplify spdi->freq rouding and explain the logic used there.

 - ddr3: calculate mtb/tCK/tns as 10^-3 (mili) int. Use ceildiv() instead of adding ROUNDING_FACTOR.

 - ddr2: calculate tckns/tns as 10^-3 (mili) int. Use ceildiv() instead of adding ROUNDING_FACTOR. Use "/ 2" instead of "* 0.5" for calculating spdi->tCL.

 - sdram: calculate tckns/tns as 10^-3 (mili) int. Use ceildiv() instead of adding ROUNDING_FACTOR.

 - remove ROUNDING_FACTOR - no longer used.

On top of the above changes, provide min() and max() macros in macros.h and move boot/macros.h into lib/macros.h.

```
Before:
   text    data     bss     dec     hex filename
  13350     868       0   14218    378a system/spd.o (x86-32)
  10279    1444       0   11723    2dcb system/spd.o (x86-64)

After:
   text    data     bss     dec     hex filename
  10277     868       0   11145    2b89 system/spd.o (x86-32)
   7770    1444       0    9214    23fe system/spd.o (x86-64)
```