### PR TITLE
x86_64: preserve r8-11 over call to interrupt handler.

### DIFF
--- a/app/interrupt.c
+++ b/app/interrupt.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2020-2022 Martin Whitaker.
+// Copyright (C) 2020-2024 Martin Whitaker.
 //
 // Derived from extract of memtest86+ lib.c:
 //
@@ -99,7 +99,12 @@ struct trap_regs {
     reg_t   dx;
     reg_t   di;
     reg_t   si;
-#ifndef __x86_64__
+#ifdef __x86_64__
+    reg_t   r8;
+    reg_t   r9;
+    reg_t   r10;
+    reg_t   r11;
+#else
     reg_t   reserved1;
     reg_t   reserved2;
     reg_t   sp;

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -6,7 +6,7 @@
 // It supports both the 32-bit and 64-bit Linux boot protocols and EFI boot
 // for the first boot of the BSP.
 //
-// Copyright (C) 2020-2022 Martin Whitaker.
+// Copyright (C) 2020-2024 Martin Whitaker.
 //
 // Derived from memtest86+ head.S:
 //
@@ -406,6 +406,10 @@ vec19:
 
 int_handler:
 	pushq	%rbp
+	pushq	%r11
+	pushq	%r10
+	pushq	%r9
+	pushq	%r8
 	pushq	%rsi
 	pushq	%rdi
 	pushq	%rdx
@@ -429,6 +433,10 @@ int_handler:
 	popq	%rdx
 	popq	%rdi
 	popq	%rsi
+	popq	%r8
+	popq	%r9
+	popq	%r10
+	popq	%r11
 	popq	%rbp
 	addq	$16, %rsp		# discard the vector number and error code
 	iretq


### PR DESCRIPTION
As noted in https://github.com/memtest86plus/memtest86plus/issues/403#issuecomment-2206973854, the x86_64 SysV calling convention does not require r8-r11 to be preserved by the callee. So we need to save and restore them in the low-level interrupt handling code in case the C interrupt() function uses them.