### PR TITLE
Add faulty memory range display mode

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -223,6 +223,8 @@ static void parse_option(const char *option, const char *params)
             error_mode = ERROR_MODE_ADDRESS;
         } else if (strncmp(params, "badram", 7) == 0) {
             error_mode = ERROR_MODE_BADRAM;
+        } else if (strncmp(params, "chunks", 7) == 0) {
+            error_mode = ERROR_MODE_RANGES;
         }
     } else if (strncmp(option, "keyboard", 9) == 0 && params != NULL) {
         if (strncmp(params, "legacy", 7) == 0) {
@@ -652,7 +654,8 @@ static void error_mode_menu(void)
     prints(POP_R+4, POP_LI, "<F2>  Error summary");
     prints(POP_R+5, POP_LI, "<F3>  Individual errors");
     prints(POP_R+6, POP_LI, "<F4>  BadRAM patterns");
-    prints(POP_R+7, POP_LI, "<F10> Exit menu");
+    prints(POP_R+7, POP_LI, "<F5>  Address ranges");
+    prints(POP_R+8, POP_LI, "<F10> Exit menu");
     printc(POP_R+3+error_mode, POP_LM, '*');
 
     bool tty_update = enable_tty;
@@ -671,6 +674,7 @@ static void error_mode_menu(void)
           case '2':
           case '3':
           case '4':
+          case '5':
             set_error_mode(ch - '1');
             break;
           case 'u':

--- a/app/config.h
+++ b/app/config.h
@@ -26,7 +26,8 @@ typedef enum {
     ERROR_MODE_NONE,
     ERROR_MODE_SUMMARY,
     ERROR_MODE_ADDRESS,
-    ERROR_MODE_BADRAM
+    ERROR_MODE_BADRAM,
+    ERROR_MODE_RANGES,
 } error_mode_t;
 
 typedef enum {

--- a/app/error.c
+++ b/app/error.c
@@ -17,6 +17,7 @@
 #include "vmem.h"
 
 #include "badram.h"
+#include "ranges.h"
 #include "config.h"
 #include "display.h"
 #include "test.h"
@@ -160,6 +161,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
     if (new_header) {
         clear_message_area();
         badram_init();
+        ranges_display_init();
     }
     last_error_mode = error_mode;
 
@@ -306,6 +308,12 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
       case ERROR_MODE_BADRAM:
         if (new_badram) {
             badram_display();
+
+      case ERROR_MODE_RANGES:
+        if (use_for_badram) {
+            if (ranges_display_insert(addr)) {
+                ranges_display();
+            }
         }
         break;
 

--- a/app/main.c
+++ b/app/main.c
@@ -42,6 +42,7 @@
 #include "unistd.h"
 
 #include "badram.h"
+#include "ranges.h"
 #include "config.h"
 #include "display.h"
 #include "error.h"
@@ -234,6 +235,8 @@ static void global_init(void)
     smbios_init();
 
     badram_init();
+
+    ranges_display_init();
 
     config_init();
 
@@ -621,6 +624,7 @@ void main(void)
                 if (!dummy_run) {
                     display_start_run();
                     badram_init();
+                    ranges_display_init();
                     error_init();
                 }
             }

--- a/app/ranges.c
+++ b/app/ranges.c
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2024 David Koňařík.
+#include "ranges.h"
+#include "display.h"
+#include "screen.h"
+#include "test.h"
+#include "assert.h"
+
+// 20 visible + 1 reserved for insert process
+#define MAX_ERROR_RANGES 21
+
+static struct {
+    uintptr_t start;
+    uintptr_t end; // Exclusive
+} ranges[MAX_ERROR_RANGES];
+static bool range_usage_map[MAX_ERROR_RANGES];
+
+void ranges_display_init(void)
+{
+    for (uint64_t i = 0; i < MAX_ERROR_RANGES; i++) {
+        range_usage_map[i] = false;
+    }
+}
+
+bool ranges_display_insert(uintptr_t addr)
+{
+    uintptr_t addr_end = addr + sizeof(testword_t);
+    // First check if we don't already contain this address or if we can't
+    // directly add it
+    for (uint64_t i = 0; i < MAX_ERROR_RANGES; i++) {
+        if (!range_usage_map[i]) {
+            continue;
+        } else if (ranges[i].start <= addr && ranges[i].end >= addr_end) {
+            return false;
+        } else if(ranges[i].end == addr) {
+            ranges[i].end = addr_end;
+            return true;
+        } else if(ranges[i].start == addr_end) {
+            ranges[i].start = addr;
+            return true;
+        }
+    }
+    
+    uint64_t range_count = 0;
+    int64_t new_range_idx = -1;
+
+    // Find a free range slot for out temporary range
+    for (uint64_t i = 0; i < MAX_ERROR_RANGES; i++) {
+        if (range_usage_map[i]) {
+            range_count++;
+        } else {
+            new_range_idx = i;
+        }
+    }
+    assert(new_range_idx != -1);
+    range_usage_map[new_range_idx] = true;
+    ranges[new_range_idx].start = addr;
+    ranges[new_range_idx].end = addr_end;
+    range_count++;
+    
+    // If we can spare the range slot, keep it as-is
+    // We always keep one free range slot for the next temp range
+    if (range_count <= MAX_ERROR_RANGES - 1) {
+        return true;
+    }
+    // Otherwise find the minimum-waste pair of ranges to merge
+    uint64_t merge_1, merge_2; // The two ranges to merge
+    uint64_t min_waste = UINT64_MAX;
+    for (uint64_t i = 0; i < MAX_ERROR_RANGES; i++) {
+        if (!range_usage_map[i]) {
+            continue;
+        }
+        for (uint64_t j = i; j < MAX_ERROR_RANGES; j++) {
+            if(!range_usage_map[j]) {
+                continue;
+            }
+            uint64_t waste =
+                ranges[i].end < ranges[j].start
+                ? ranges[j].start - ranges[i].end
+                : ranges[i].start - ranges[j].end;
+            if(waste < min_waste) {
+                merge_1 = i;
+                merge_2 = j;
+                min_waste = waste;
+            }
+        }
+    }
+    assert(min_waste != UINT64_MAX);
+    // Merge the two ranges and free the second
+    ranges[merge_1].end = ranges[merge_2].end;
+    range_usage_map[merge_2] = false;
+
+    return true;
+}
+
+void ranges_display()
+{
+    check_input();
+
+    clear_message_area();
+    display_pinned_message(0, 0, "Faulty memory ranges (start,length):");
+    scroll();
+    int col = 0;
+    for (uint64_t i = 0; i < MAX_ERROR_RANGES; i++) {
+        if (!range_usage_map[i]) {
+            continue;
+        }
+        int text_width = 2 * (16 + 2) + 2;
+        if (col > SCREEN_WIDTH - text_width) {
+            scroll();
+            col = 0;
+        }
+        display_scrolled_message(
+            col, "0x%016x,0x%x",
+            ranges[i].start, ranges[i].end - ranges[i].start);
+        col += text_width;
+    }
+}

--- a/app/ranges.h
+++ b/app/ranges.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2024 David Koňařík.
+//
+// Error display option that shows ranges of faulty memory locations.
+#ifndef RANGES_H 
+#define RANGES_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void ranges_display_init();
+
+/**
+ * Returns true if the range display should be redrawn
+ */
+bool ranges_display_insert(uintptr_t addr);
+
+void ranges_display();
+
+#endif // RANGES_H

--- a/build32/Makefile
+++ b/build32/Makefile
@@ -77,6 +77,7 @@ TST_OBJS = tests/addr_walk1.o \
            tests/tests.o
 
 APP_OBJS = app/badram.o \
+           app/ranges.o \
            app/config.o \
            app/display.o \
            app/error.o \

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -76,6 +76,7 @@ TST_OBJS = tests/addr_walk1.o \
            tests/tests.o
 
 APP_OBJS = app/badram.o \
+           app/ranges.o \
            app/config.o \
            app/display.o \
            app/error.o \


### PR DESCRIPTION
I've added a new error reporting mode to roughly show which ranges of memory are affected. It's pretty similar to the BadRAM mode, except more "dumb": Instead of showing an address and mask, it just shows you a number of (address, range size) pairs covering all reported errors. This has lower information density, but this format is readily usable with a [stock Linux kernel](https://unix.stackexchange.com/a/76188) or maybe even [Windows](https://www.memtest86.com/blacklist-ram-badram-badmemorylist.html). The BadRAM patches are neat, but they seem to only be available [for very old Linux versions](http://rick.vanrein.org/linux/badram/download.html).

I tested it in QEMU by manually calling `data_error()`. Sadly I couldn't test it on real hardware, because the machine I developed this for seems to have magically healed its memory errors. Go figure.

Comments and/or suggestions are welcome.