### PR TITLE
Add support for Intel MTL & ARL CPUs

### DIFF
--- a/system/cpuinfo.c
+++ b/system/cpuinfo.c
@@ -375,17 +375,17 @@ static void determine_imc(void)
         switch (cpuid_info.version.model) {
           case 0x5:
             switch (cpuid_info.version.extendedModel) {
-              case 2:
+              case 0x2:
                 imc.family = IMC_NHM;         // Core i3/i5 1st Gen 45 nm (Nehalem/Bloomfield)
                 break;
-              case 3:
+              case 0x3:
                 imc.family = IMC_CLT;
                 enable_temperature = false;   // Atom Clover Trail
                 break;
-              case 4:
+              case 0x4:
                 imc.family = IMC_HSW_ULT;     // Core 4th Gen (Haswell-ULT)
                 break;
-              case 5:
+              case 0x5:
                 imc.family = IMC_SKL_SP;      // Skylake/Cascade Lake/Cooper Lake (Server)
                 break;
               default:
@@ -395,22 +395,25 @@ static void determine_imc(void)
 
           case 0x6:
             switch (cpuid_info.version.extendedModel) {
-              case 2:
+              case 0x2:
                 imc.family = IMC_TNC;         // Atom Tunnel Creek / Lincroft
                 enable_temperature = false;
                 break;
-              case 3:
+              case 0x3:
                 imc.family = IMC_CDT;         // Atom Cedar Trail
                 enable_temperature = false;
                 break;
-              case 4:
+              case 0x4:
                 imc.family = IMC_HSW;         // Core 4th Gen (Haswell w/ GT3e)
                 break;
-              case 5:
+              case 0x5:
                 imc.family = IMC_BDW_DE;      // Broadwell-DE (Server)
                 break;
-              case 6:
+              case 0x6:
                 imc.family = IMC_CNL;         // Cannon Lake
+                break;
+              case 0xC:
+                imc.family = IMC_ARL;         // Core 15th Gen (Arrow Lake)
                 break;
               default:
                 break;
@@ -455,6 +458,9 @@ static void determine_imc(void)
                 break;
               case 0x9:
                 imc.family = IMC_ADL;         // Core 12th Gen (Alder Lake-S)
+                break;
+              case 0xA:
+                imc.family = IMC_MTL;         // Core 14th Gen (Meteor Lake)
                 break;
               default:
                 break;

--- a/system/cpuinfo.h
+++ b/system/cpuinfo.h
@@ -31,6 +31,7 @@
 #define IMC_ADL         0x1100  // Core 12th Gen (Alder Lake-S)
 #define IMC_RPL         0x1110  // Core 13th Gen (Raptor Lake)
 #define IMC_MTL         0x1120  // Core 14th Gen (Meteor Lake)
+#define IMC_ARL         0x1130  // Core 15th Gen (Arrow Lake)
 
 #define IMC_NHM_E       0x2010  // Core i7 1st Gen 45 nm (Nehalem-E)
 #define IMC_SNB_E       0x2020  // Core 2nd Gen (Sandy Bridge-E)

--- a/system/hwquirks.c
+++ b/system/hwquirks.c
@@ -84,10 +84,10 @@ static void amd_k8_revfg_temp(void)
     }
 
     // K8 Rev G Desktop requires an additional offset.
-    if (cpuid_info.version.extendedModel < 6 && cpuid_info.version.extendedModel > 7)   // Not Rev G
+    if (cpuid_info.version.extendedModel < 6 || cpuid_info.version.extendedModel > 7)   // Not Rev G
         return;
 
-    if (cpuid_info.version.extendedModel == 6 && cpuid_info.version.extendedModel < 9)  // Not Desktop
+    if (cpuid_info.version.extendedModel == 6 && cpuid_info.version.model < 9)  // Not Desktop
         return;
 
     uint16_t brandID = (cpuid_info.version.extendedBrandID >> 9) & 0x1f;

--- a/system/imc/imc.h
+++ b/system/imc/imc.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2004-2023 Sam Demeulemeester
+// Copyright (C) 2004-2024 Sam Demeulemeester
 #ifndef _IMC_H_
 #define _IMC_H_
 
@@ -24,6 +24,9 @@ void get_imc_config_intel_icl(void);
 
 /* Memory configuration Detection for Intel Alder Lake */
 void get_imc_config_intel_adl(void);
+
+/* Memory configuration Detection for Intel Metor Lake */
+void get_imc_config_intel_mtl(void);
 
 /* Memory configuration Detection for Loongson LoongArch DDR4 CPU family */
 void get_imc_config_loongson_ddr4(void);

--- a/system/imc/intel_mtl.c
+++ b/system/imc/intel_mtl.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2004-2024 Sam Demeulemeester
+//
+// ------------------------
+//
+// Platform-specific code for Intel Meteor Lake (MTL) and
+// Arrow-Lake (ARL) CPUs
+//
+
+#include "cpuinfo.h"
+#include "memctrl.h"
+#include "msr.h"
+#include "pci.h"
+#include "vmem.h"
+
+#include "imc.h"
+
+#define MTL_MMR_BASE_REG_LOW    0x48
+#define MTL_MMR_BASE_REG_HIGH   0x4C
+
+#define MTL_MMR_WINDOW_RANGE    (1UL << 17)
+#define MTL_MMR_BASE_MASK       0x3FFFFFE0000
+
+#define MTL_MMR_MC1_OFFSET      0x10000
+#define MTL_MMR_CH1_OFFSET      0x800
+
+#define MTL_MMR_IC_DECODE       0xD800
+#define MTL_MMR_CH0_DIMM_REG    0xD80C
+
+#define MTL_MMR_CH0_PRE_REG     0xE000
+#define MTL_MMR_CH0_CAS_REG     0xE070
+#define MTL_MMR_CH0_ACT_REG     0xE138
+
+#define MTL_MMR_PTGRAM_REG      0x13D98
+
+void get_imc_config_intel_mtl(void)
+{
+    uint64_t mmio_reg;
+    uint32_t cha, chb, offset;
+    uint32_t tmp;
+    uintptr_t *ptr;
+    uint32_t *ptr32;
+
+    // Get Memory Mapped Register Base Address (Enable MMIO if needed)
+    mmio_reg = pci_config_read32(0, 0, 0, MTL_MMR_BASE_REG_LOW);
+    if (!(mmio_reg & 0x1)) {
+        pci_config_write32( 0, 0, 0, MTL_MMR_BASE_REG_LOW, mmio_reg | 1);
+        mmio_reg = pci_config_read32(0, 0, 0, MTL_MMR_BASE_REG_LOW);
+        if (!(mmio_reg & 0x1)) return;
+    }
+
+    mmio_reg |= (uint64_t)pci_config_read32(0, 0, 0, MTL_MMR_BASE_REG_HIGH) << 32;
+    mmio_reg &= MTL_MMR_BASE_MASK;
+
+#ifndef __x86_64__
+    if (mmio_reg >= (1ULL << 32)) return;    // MMIO is outside reachable range (> 32bit)
+#endif
+
+    uintptr_t mchbar_addr = map_region(mmio_reg, MTL_MMR_WINDOW_RANGE, false);
+
+    // Get channel configuration & IMC width
+    cha = *(uintptr_t*)(mchbar_addr + MTL_MMR_CH0_DIMM_REG);
+    tmp = *(uintptr_t*)(mchbar_addr + MTL_MMR_IC_DECODE);
+    cha = ~cha ? 1 << (((tmp >> 27) & 3) + 4) : 0;
+
+    chb = *(uintptr_t*)(mchbar_addr + MTL_MMR_CH0_DIMM_REG + MTL_MMR_MC1_OFFSET);
+    tmp = *(uintptr_t*)(mchbar_addr + MTL_MMR_IC_DECODE + MTL_MMR_MC1_OFFSET);
+    chb = ~chb ? 1 << (((tmp >> 27) & 3) + 4) : 0;
+
+    offset = cha ? 0x0 : MTL_MMR_MC1_OFFSET;
+    imc.width = (cha + chb) * 2;
+
+    // MTL+ only supports DDR5
+    imc.type = "DDR5";
+
+    // Get Memory Clock
+    ptr32 = (uint32_t*)(mchbar_addr + MTL_MMR_PTGRAM_REG);
+
+    switch((*ptr32 >> 20) & 0xF) {
+        default:
+        case 0x1:
+            imc.freq = 200;
+            break;
+        case 0x2:
+            imc.freq = 100;
+            break;
+        case 0xA:
+            imc.freq = 133;
+            break;
+        case 0xB:
+            imc.freq = 66;
+            break;
+        case 0xC:
+            imc.freq = 33;
+            break;
+    }
+
+    imc.freq *= (*ptr32 >> 12) & 0xFF; // * Divider
+    imc.freq *= (((*ptr32 >> 24) & 1) + 1) * 2; // * Gear * DDR
+
+    // Get DRAM Timings
+    ptr = (uintptr_t*)(mchbar_addr + offset + MTL_MMR_CH0_CAS_REG);
+    imc.tCL = (*ptr >> 16) & 0x7F;
+
+    ptr = (uintptr_t*)(mchbar_addr + offset + MTL_MMR_CH0_ACT_REG);
+    imc.tRCD = (*ptr >> 22) & 0xFF;
+
+    ptr = (uintptr_t*)(mchbar_addr + offset + MTL_MMR_CH0_PRE_REG);
+    imc.tRP = (*ptr >> 10) & 0xFF;
+
+    ptr32 = (uint32_t*)((uintptr_t)mchbar_addr + offset + MTL_MMR_CH0_PRE_REG + 4);
+    imc.tRAS = (*ptr32 >> 13) & 0x1FF;
+}

--- a/system/memctrl.c
+++ b/system/memctrl.c
@@ -57,6 +57,9 @@ void memctrl_init(void)
       case IMC_ADL:
         get_imc_config_intel_adl();
         break;
+      case IMC_ARL:
+      case IMC_MTL:
+        get_imc_config_intel_mtl();
       default:
         break;
     }

--- a/system/smbus.h
+++ b/system/smbus.h
@@ -37,10 +37,12 @@
 #define SMBHSTSTS_INTR          0x02
 #define SMBHSTSTS_HOST_BUSY     0x01
 
+/* i801 Hosts Control register bits */
 #define SMBHSTCNT_QUICK             0x00
 #define SMBHSTCNT_BYTE              0x04
 #define SMBHSTCNT_BYTE_DATA         0x08
 #define SMBHSTCNT_WORD_DATA         0x0C
+#define SMBHSTCNT_PROC_CALL         0x10
 #define SMBHSTCNT_BLOCK_DATA        0x14
 #define SMBHSTCNT_I2C_BLOCK_DATA    0x18
 #define SMBHSTCNT_LAST_BYTE         0x20


### PR DESCRIPTION
Also change the DDR5 SPD Bank switching code to avoid issues when BIOS Write-lock the I2C bus 

Fix #110 
Fix #407 