### PR TITLE
Add VT8237S SMBus controller support

### DIFF
--- a/system/i2c_x86.c
+++ b/system/i2c_x86.c
@@ -297,7 +297,7 @@ static bool find_smb_controller(uint16_t vid, uint16_t did)
                 case 0x3177: // 8235
                 case 0x3227: // 8237
                 // case 0x3337: // 8237A
-                // case 0x3372: // 8237S
+                case 0x3372: // 8237S
                 // case 0x3287: // 8251
                 // case 0x8324: // CX700
                 // case 0x8353: // VX800


### PR DESCRIPTION
With this one-liner, an ASRock 4CoreDual-SATA2 PCI/AGP/PCIe + DDR/DDR2 dual hybrid MB (probably R2.0, I forgot to double-check) can display SPD data from a DDR2 stick twice in a row:
![VT8237S_SPD](https://github.com/user-attachments/assets/42bf5c4b-5618-428e-80dd-ff2b92ec3e48)