### PR TITLE
loongarch: Add 64-bit PCIe memory space mapping and change the stable timer as the main timer

### DIFF
--- a/boot/loongarch/startup64.S
+++ b/boot/loongarch/startup64.S
@@ -331,14 +331,6 @@ Jmp:
     li.w    $t0, 0xB0        # PG mode, load/store cacheable, instructions cacheable, disable intrrupts, DMWn effected.
     csrwr   $t0, LOONGARCH_CSR_CRMD
 
-    //
-    // Set PMCNT0.
-    //
-    li.w      $t0, (0x1 << 16)
-    li.w      $t1, ((0x1 << 16) | 0x3FF)
-    csrxchg   $t0, $t1, LOONGARCH_CSR_PERFCTRL0
-    csrwr     $zero, LOONGARCH_CSR_PERFCNTR0
-
     # Enable all IPIs
     li.w       $t0, 0xFFFFFFFF
     li.w       $t1, 0x1004

--- a/system/loongarch/vmem.c
+++ b/system/loongarch/vmem.c
@@ -29,7 +29,9 @@ extern uint8_t highest_map_bit;
 
 uintptr_t map_region(uintptr_t base_addr, size_t size __attribute__((unused)), bool only_for_startup __attribute__((unused)))
 {
-    if (((base_addr < 0x80000000) && (base_addr >= 0x30000000)) || ((base_addr & PCI_IO_PERFIX) != 0x0)) {
+    if (((base_addr < 0x80000000) && (base_addr >= 0x30000000)) ||         // 32-bit PCI memory space
+      ((base_addr < 0xFD00000000ULL) && (base_addr >= 0x8000000000ULL)) || // 64-bit PCI memory space
+      ((base_addr & PCI_IO_PERFIX) != 0x0)) {
         return MMIO_BASE | base_addr;
     } else if ((base_addr < 0x20000000) && (base_addr > 0x10000000)) {
         return DMW0_BASE | base_addr;

--- a/system/smp.c
+++ b/system/smp.c
@@ -1059,14 +1059,6 @@ int smp_start(cpu_state_t cpu_state[MAX_CPUS])
 #endif
     }
 
-#if defined(__loongarch_lp64)
-    //
-    // MP sync the PMCNT0 with AP
-    //
-    __csrxchg_d(1 << 16, (1 << 16 | 0x3FF), LOONGARCH_CSR_PERFCTRL0);
-    __csrwr_d(0x0, LOONGARCH_CSR_PERFCNTR0);
-#endif
-
 #if SEQUENTIAL_AP_START
     return 0;
 #else


### PR DESCRIPTION
Added the 64-bit PCIe memory space mapping. From 0x8000000000ULL to 0xFD00000000ULL are LoongArch 64-bit PCIe memory spaces and need to be mapped.

Since some LoongArch64 CPUs stop the performance counters when ilde, the running time displayed on the screen is incorrect. Using stable counter can solve this problem, so remove the performance counters time, and add stable counter time.

