### PR TITLE
Improve BadRAM pattern collection and add more condensed error reporting modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ The configuration menu allows the user to:
     * error summary
     * individual errors
     * BadRAM patterns
+    * Linux memmap
+    * bad pages
   * select which of the available CPU cores are used (at startup only)
     * a maximum of 256 CPU cores can be selected, due to memory and
       display limits
@@ -291,7 +293,9 @@ The error reporting mode may be changed at any time without disrupting the
 current test sequence. Error statistics are collected regardless of the
 current error reporting mode (so switching to error summary mode will show
 the accumulated statistics since the current test sequence started). BadRAM
-patterns are only accumulated when in BadRAM mode.
+patterns are only accumulated when in BadRAM mode. Linux memmap regions are
+only accumulated when in memmap mode. Bad page numbers are only accumulated
+when in bad page mode.
 
 Any change to the selected tests, address range, or CPU sequencing mode will
 start a new test sequence and reset the error statistics.
@@ -343,17 +347,18 @@ instance:
 ### BadRAM Patterns
 
 The BadRAM patterns mode accumulates and displays error patterns for use with
-the [Linux BadRAM feature](http://rick.vanrein.org/linux/badram/). Lines are
-printed in the form `badram=F1,M1,F2,M2...` In each `F,M` pair, the `F`
-represents a fault address and the `M` is a bitmask for that address. These
+the [Linux BadRAM feature](http://rick.vanrein.org/linux/badram/) or [GRUB
+badram command](https://www.gnu.org/software/grub/manual/grub/grub.html#badram).
+Lines are printed in the form `badram=F1,M1,F2,M2...` In each `F,M` pair, the
+`F` represents a fault address and the `M` is a bitmask for that address. These
 patterns state that faults have occurred in addresses that equal F on all `1`
-bits in M. Such a pattern may capture more errors that actually exist, but
+bits in M. Such a pattern may capture more errors than actually exist, but
 at least all the errors are captured. These patterns have been designed to
 capture regular patterns of errors caused by the hardware structure in a terse
 syntax.
 
 The BadRAM patterns are grown incrementally rather than calculated from an
-overview of all errors. The number of pairs is constrained to ten for a
+overview of all errors. The number of pairs is constrained to 20 for a
 number of practical reasons. As a result, handcrafting patterns from the
 output in address printing mode may, in exceptional cases, yield better
 results.
@@ -361,6 +366,39 @@ results.
 **NOTE** As mentioned in the individual test descriptions, the walking-ones
 address test (test 0) and the block move test (test 7) do not contribute to
 the BadRAM patterns as these tests do not allow the exact address of the
+fault to be determined.
+
+### Linux memmap
+
+The Linux memmap mode accumulates and displays faulty memory regions for use
+with the [Linux memmap boot command line option]
+(https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt).
+Lines are printed in the form `memmap=S1$A1,S2,A2...` In each `S,A` pair, the
+`A` represents the first address in the region and the `S` is the size of the
+region (in bytes). Up to 20 faulty memory regions are recorded. Once more than
+20 regions of contiguous faulty locations have been found, regions will be
+merged, which will mean some regions include non-faulty locations. The program
+will try to minimise the number of non-faulty locations that are included.
+
+**NOTE** As mentioned in the individual test descriptions, the walking-ones
+address test (test 0) and the block move test (test 7) do not contribute to
+the faulty memory regions as these tests do not allow the exact address of
+the fault to be determined.
+
+### Bad Pages
+
+The bad pages mode accumulates and displays faulty memory page numbers. These
+may be used with the Windows bcdedit command to add those pages to the Windows
+PFA memory list. The page numbers are either displayed as a single hexadecimal
+number (e.g. `0x20`) or a range of hexadecimal page numbers (e.g. `0x20..0x2a`).
+Up to 20 ranges of faulty pages are recorded. Once more than 20 ranges of
+contiguous faulty pages have been found, ranges will be merged, which will
+mean some ranges include non-faulty pages. The program will try to minimise
+the number of non-faulty pages that are included.
+
+**NOTE** As mentioned in the individual test descriptions, the walking-ones
+address test (test 0) and the block move test (test 7) do not contribute to
+the faulty page numbers as these tests do not allow the exact address of the
 fault to be determined.
 
 ## Trouble-shooting Memory Errors
@@ -517,8 +555,8 @@ memory region in turn. Caching is enabled for all but the first test.
 ### Test 0 : Address test, walking ones, no cache
 
 In each memory region in turn, tests all address bits by using a walking
-ones address pattern. Errors from this test are not used to calculate BadRAM
-patterns.
+ones address pattern. Errors from this test do not contribute to BadRAM
+patterns, memmap regions, or bad page regions.
 
 ### Test 1 : Address test, own address in window
 
@@ -571,7 +609,7 @@ the movs instruction. After the moves are completed the data patterns are
 checked. Because the data is checked only after the memory moves are completed
 it is not possible to know where the error occurred. The addresses reported
 are only for where the bad pattern was found. In consequence, errors from this
-test are not used to calculate BadRAM patterns.
+test do not contribute to BadRAM patterns, memmap regions, or bad page regions.
 
 ### Test 8 : Random number sequence
 

--- a/app/badram.c
+++ b/app/badram.c
@@ -38,7 +38,7 @@
 #define PATTERNS_SIZE (MAX_PATTERNS + 1)
 
 // DEFAULT_MASK covers a uintptr_t, since that is the testing granularity.
-#ifdef __x86_64__
+#if (ARCH_BITS == 64)
 #define DEFAULT_MASK (UINT64_MAX << 3)
 #else
 #define DEFAULT_MASK (UINT64_MAX << 2)

--- a/app/badram.c
+++ b/app/badram.c
@@ -36,7 +36,7 @@
 // Constants
 //------------------------------------------------------------------------------
 
-#define MAX_PATTERNS 10
+#define MAX_PATTERNS 20
 #define PATTERNS_SIZE (MAX_PATTERNS + 1)
 
 // DEFAULT_MASK covers a uintptr_t, since that is the testing granularity.

--- a/app/badram.c
+++ b/app/badram.c
@@ -225,6 +225,15 @@ static int display_hex_uint64(int col, uint64_t value)
 #endif
 }
 
+static int scroll_if_needed(int col, int text_width, int indent)
+{
+    if (col > (SCREEN_WIDTH - text_width)) {
+        scroll();
+        col = indent;
+    }
+    return col;
+}
+
 //------------------------------------------------------------------------------
 // Public Functions
 //------------------------------------------------------------------------------
@@ -297,11 +306,7 @@ void badram_display(void)
         if (i > 0) {
             col = display_scrolled_message(col, ",");
         }
-        int text_width = num_digits(patterns[i].addr) + num_digits(patterns[i].mask) + 5;
-        if (col > (SCREEN_WIDTH - text_width)) {
-            scroll();
-            col = 7;
-        }
+        col = scroll_if_needed(col, num_digits(patterns[i].addr) + num_digits(patterns[i].mask) + 5, 7);
         col = display_hex_uint64(col, patterns[i].addr);
         col = display_scrolled_message(col, ",");
         col = display_hex_uint64(col, patterns[i].mask);

--- a/app/badram.h
+++ b/app/badram.h
@@ -4,10 +4,23 @@
 /**
  * \file
  *
- * Provides functions for generating patterns for the Linux kernel BadRAM extension.
+ * Provides functions for recording and displaying faulty address locations
+ * in a condensed form. The display format is determined by the current value
+ * of the error_mode config setting as follows:
+ *
+ *  - ERROR_MODE_BADRAM
+ *      records and displays patterns in the format used by the Linux BadRAM
+ *      extension or GRUB badram command
+ *
+ *  - ERROR_MODE_MEMMAP
+ *      records and displays address ranges in the format used by the Linux
+ *      memmap boot command line option
+ *
+ *  - ERROR_MODE_PAGES
+ *      records and displays memory page numbers
  *
  *//*
- * Copyright (C) 2020-2022 Martin Whitaker.
+ * Copyright (C) 2020-2024 Martin Whitaker.
  */
 
 #include <stdbool.h>
@@ -16,19 +29,20 @@
 #include "test.h"
 
 /**
- * Initialises the pattern array.
+ * Initialises the fault record. This must be called each time error_mode is
+ * changed.
  */
 void badram_init(void);
 
 /**
- * Inserts a single faulty address into the pattern array. Returns
- * true iff the array was changed.
+ * Inserts a single faulty address into the fault record. Returns true iff
+ * the fault record was changed.
  */
 bool badram_insert(testword_t page, testword_t offset);
 
 /**
- * Displays the pattern array in the scrollable display region in the
- * format used by the Linux kernel.
+ * Displays the fault record in the scrollable display region in the format
+ * determined by error_mode.
  */
 void badram_display(void);
 

--- a/app/config.c
+++ b/app/config.c
@@ -223,6 +223,10 @@ static void parse_option(const char *option, const char *params)
             error_mode = ERROR_MODE_ADDRESS;
         } else if (strncmp(params, "badram", 7) == 0) {
             error_mode = ERROR_MODE_BADRAM;
+        } else if (strncmp(params, "memmap", 7) == 0) {
+            error_mode = ERROR_MODE_MEMMAP;
+        } else if (strncmp(params, "pages", 6) == 0) {
+            error_mode = ERROR_MODE_PAGES;
         }
     } else if (strncmp(option, "keyboard", 9) == 0 && params != NULL) {
         if (strncmp(params, "legacy", 7) == 0) {
@@ -652,7 +656,9 @@ static void error_mode_menu(void)
     prints(POP_R+4, POP_LI, "<F2>  Error summary");
     prints(POP_R+5, POP_LI, "<F3>  Individual errors");
     prints(POP_R+6, POP_LI, "<F4>  BadRAM patterns");
-    prints(POP_R+7, POP_LI, "<F10> Exit menu");
+    prints(POP_R+7, POP_LI, "<F5>  Linux memmap");
+    prints(POP_R+8, POP_LI, "<F6>  Bad pages");
+    prints(POP_R+9, POP_LI, "<F10> Exit menu");
     printc(POP_R+3+error_mode, POP_LM, '*');
 
     bool tty_update = enable_tty;
@@ -671,6 +677,8 @@ static void error_mode_menu(void)
           case '2':
           case '3':
           case '4':
+          case '5':
+          case '6':
             set_error_mode(ch - '1');
             break;
           case 'u':
@@ -679,7 +687,7 @@ static void error_mode_menu(void)
             }
             break;
           case 'd':
-            if (error_mode < 3) {
+            if (error_mode < 5) {
                 set_error_mode(error_mode + 1);
             }
             break;

--- a/app/config.h
+++ b/app/config.h
@@ -26,7 +26,9 @@ typedef enum {
     ERROR_MODE_NONE,
     ERROR_MODE_SUMMARY,
     ERROR_MODE_ADDRESS,
-    ERROR_MODE_BADRAM
+    ERROR_MODE_BADRAM,
+    ERROR_MODE_MEMMAP,
+    ERROR_MODE_PAGES,
 } error_mode_t;
 
 typedef enum {

--- a/app/error.c
+++ b/app/error.c
@@ -185,7 +185,7 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
     bool new_address = (type != NEW_MODE);
 
     bool new_badram = false;
-    if (error_mode == ERROR_MODE_BADRAM && use_for_badram) {
+    if (error_mode >= ERROR_MODE_BADRAM && use_for_badram) {
         new_badram = badram_insert(page, offset);
     }
 
@@ -304,6 +304,8 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
         break;
 
       case ERROR_MODE_BADRAM:
+      case ERROR_MODE_MEMMAP:
+      case ERROR_MODE_PAGES:
         if (new_badram) {
             badram_display();
         }


### PR DESCRIPTION
We have two outstanding PRs (#357 and #435) that propose additional error reporting modes. On reviewing them, I felt that the functionality could be provided more cheaply by extending the existing BadRAM code. In the process I've made a few improvements to the BadRAM pattern collection. For reviewers, I suggest reviewing the individual commits in sequence.

The changes are:

1. Make the initial default mask for a BadRAM pattern depend on `ARCH_BITS` not on `__x86_64__`. I guess this was missed when we added `ARCH_BITS`.
2. Change the BadRAM display to omit leading zeros from addresses - a cosmetic change, but useful for the new error reporting modes.
3. Merge BadRAM patterns immediately when adding a new faulty location if that wouldn't add any (new) non-faulty locations. This was something that was lost in the previous BadRAM optimisation (#178).
4. Add two new error reporting modes, one to display faulty memory regions in the format used by the Linux memmap boot command line option, the other to display a list of faulty memory page numbers.