### PR TITLE
Fix LD error while linking LoongArch64 EFI binary

### DIFF
--- a/build64/la64/Makefile
+++ b/build64/la64/Makefile
@@ -183,7 +183,9 @@ memtest.debug: memtest_shared
 
 memtest.efi: memtest_shared.bin boot/loongarch/header.o ldscripts/memtest_efi.lds
 	$(eval SIZES=$(shell size -B -d memtest_shared | grep memtest_shared))
-	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_shared.bin -o memtest.efi
+	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_shared.bin -o memtest.elf
+	$(OBJCOPY) -O binary memtest.elf memtest.efi
+	rm -f memtest.elf
 
 esp.img: memtest.efi
 	@mkdir -p iso/EFI/BOOT

--- a/build64/la64/ldscripts/memtest_efi.lds
+++ b/build64/la64/ldscripts/memtest_efi.lds
@@ -1,4 +1,4 @@
-OUTPUT_FORMAT("binary")
+OUTPUT_FORMAT("elf64-loongarch")
 OUTPUT_ARCH(loongarch)
 
 ENTRY(head);


### PR DESCRIPTION
I reinstalled from scratch the latest arch linux on the LA64 dev plaform (with all latest LA64 packages).
Unfortunately, I noticed the linker now fails while trying to link the efi file with the following message:

`ld: error: cannot change output format whilst linking LoongArch binaries`

I'm not sure if a special configuration was added previously on the dev platform or if something changed in ld

Anyway, slightly changing the build process to output an elf then converting it to binary using objcopy solves the issue.

 @kilaterlee > does this looks file to you?