### PR TITLE
Ignore PS/2 mouse events (issue #456)

### DIFF
--- a/system/keyboard.c
+++ b/system/keyboard.c
@@ -248,9 +248,13 @@ char get_key(void)
 
     static bool escaped = false;
     if (keyboard_types & KT_LEGACY) {
-        uint8_t c = inb(0x64);
-        if (c & 0x01) {
-            c = inb(0x60);
+        uint8_t status = inb(0x64);
+        if (status & 0x01) {
+            uint8_t c = inb(0x60);
+            if (status & 0x20) {
+                // Ignore mouse events.
+                return '\0';
+            }
             if (escaped) {
                 escaped = false;
                 switch (c) {


### PR DESCRIPTION
If a legacy BIOS has enabled PS/2 mouse input, the bytes received on port 0x60 may come from either the keyboard or the mouse. Currently we treat all bytes as keyboard input, which means mouse input will be translated into arbitrary key codes. This may cause a memory test to be interrupted or aborted. We should instead disable or ignore any mouse input.

Although it should be possible to reconfigure the PS/2 controller to disable mouse input, it's quite likely that there's some quirky H/W out there that makes this more complicated than it seems. The simple solution is to detect mouse input by checking whether bit 5 of the received byte is set and discarding it if so.

This fix has been tested by the user who reported the issue in #456.