### PR TITLE
Test build on Ubuntu 24.04

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         arch: [i386, x86_64, la64]
 
     steps:


### PR DESCRIPTION
Today, for another project, I noticed that Ubuntu 24.04 runners have become available on Github at some point, so I started using them there... and I'm now doing the same here.
At this point, I think we might simultaneously stop checking compatibility with Ubuntu 20.04, which will soon be EOL anyway. What's more, building the `simd` branch produces an error on Ubuntu 20.04 but not 22.04 or my Debian sid amd64.

@kilaterlee : the build fails on Ubuntu 24.04 la64 because of a segmentation fault in xorriso ?