### PR TITLE
build64: Fix iso creation on LoongArch

### DIFF
--- a/build64/la64/Makefile
+++ b/build64/la64/Makefile
@@ -195,8 +195,8 @@ esp.img: memtest.efi
 	mcopy -s -i esp.img iso/EFI ::
 
 memtest.iso: esp.img
-	xorrisofs -pad -R -J -volid MT86PLUS_64 -graft-points \
-		  -part_like_isohybrid -iso_mbr_part_type 0x00 -append_partition 2 0xef ./esp.img \
+	xorrisofs -pad -R -J -volid MT86PLUS_64_EFI_ONLY -no-emul-boot -graft-points \
+		  -append_partition 2 0xef ./esp.img \
 		  -o ./memtest.iso /EFI=./iso/EFI
 
 iso: memtest.iso


### PR DESCRIPTION
Ubuntu 24.04 uses xorriisofs V1.5.6, which checks for hybird formats when `-part_like_isohybird` is used, and will report the core dump if the MBR is not included.

Removed the `-part_like_isohybird` option on LoongArch to fix it, and only use EFI boot mode on LoongArch.