### PR TITLE
Display related optimizations and performance improvements 

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -141,7 +141,7 @@ void display_init(void)
 
     set_foreground_colour(BLUE);
     set_background_colour(WHITE);
-    clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
+    clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_MAX_COL);
     prints(ROW_FOOTER, 0, " <ESC> Exit  <F1> Configuration  <Space> Scroll Lock");
     prints(ROW_FOOTER, 64, MT_VERSION "." GIT_HASH);
 #if defined (__x86_64__)
@@ -306,10 +306,10 @@ void display_start_run(void)
     if (ecc_status.ecc_enabled) {
         clear_screen_region(8, 49, 8, 53);                  // pass number
         clear_screen_region(8, 61, 8, 68);                  // error count
-        clear_screen_region(8, 74, 8, SCREEN_WIDTH - 1);    // ecc error count
+        clear_screen_region(8, 74, 8, SCREEN_MAX_COL);      // ecc error count
     } else {
         clear_screen_region(8, 49, 8, 59);                  // pass number
-        clear_screen_region(8, 68, 8, SCREEN_WIDTH - 1);    // error count
+        clear_screen_region(8, 68, 8, SCREEN_MAX_COL);      // error count
     }
 
     display_pass_count(0);
@@ -330,7 +330,7 @@ void display_start_run(void)
 
 void display_start_pass(void)
 {
-    clear_screen_region(1, 39, 1, SCREEN_WIDTH - 1);    // progress bar
+    clear_screen_region(1, 39, 1, SCREEN_MAX_COL);      // progress bar
     display_pass_percentage(0);
     pass_bar_length = 0;
     pass_ticks = 0;
@@ -338,10 +338,9 @@ void display_start_pass(void)
 
 void display_start_test(void)
 {
-    clear_screen_region(2, 39, 3, SCREEN_WIDTH - 1);    // progress bar, test details
-    clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6);    // Avoid erasing paging mode
-    clear_screen_region(5, 39, 5, SCREEN_WIDTH - 1);
-    clear_screen_region(3, 36, 3, 37);                  // test number
+    clear_screen_region(2, 39, 2, SCREEN_MAX_COL);      // test progress bar
+    clear_screen_region(4, 39, 4, SCREEN_MAX_COL - 5);  // test addr / desc, keep addr mode
+    clear_screen_region(5, 39, 5, SCREEN_MAX_COL);      // test pattern
     display_test_percentage(0);
     display_test_number(test_num);
     display_test_description(test_list[test_num].description);

--- a/app/display.h
+++ b/app/display.h
@@ -157,7 +157,7 @@ typedef enum {
     printi(3, 36, number, 2, false, true)
 
 #define display_test_description(str) \
-    prints(3, 39, str)
+    printf_region(3, 39, SCREEN_MAX_COL, "[%s]", str)
 
 #define display_test_addresses(pb, pe, total) \
     printf_region(4, 39, SCREEN_MAX_COL - 5, "%kB - %kB [%kB of %kB]", pb, pe, (pe) - (pb), total)

--- a/app/display.h
+++ b/app/display.h
@@ -35,11 +35,19 @@
 
 #define ERROR_LIMIT     UINT64_C(999999999999)
 
+#define SCREEN_MAX_COL  (SCREEN_WIDTH - 1)
+
 typedef enum {
     DISPLAY_MODE_NA,
     DISPLAY_MODE_SPD,
     DISPLAY_MODE_IMC
 } display_mode_t;
+
+#define printf_region(row, col_start, col_end, ...) \
+    clear_screen_region(row, printf(row, col_start, __VA_ARGS__), row, col_end)
+
+#define prints_region(row, col_start, col_end, str) \
+    clear_screen_region(row, prints(row, col_start, str), row, col_end)
 
 #define display_cpu_model(str) \
     prints(0, 30, str)
@@ -78,43 +86,40 @@ typedef enum {
     prints(7, 68, status)
 
 #define display_threading(nb, mode) \
-    printf(7,31, "%uT (%s)", nb, mode)
+    printf(7, 31, "%uT (%s)", nb, mode)
 
 #define display_threading_disabled() \
-    prints(7,31, "Disabled")
+    prints(7, 31, "Disabled")
 
 #define display_cpu_topo_hybrid(num_pcores, num_ecores, num_threads) \
-    { \
-        clear_screen_region(7, 5, 7, 25); \
-        printf(7, 5, "%uP+%uE-Cores (%uT)", num_pcores, num_ecores, num_threads); \
-    }
+    printf_region(7, 5, 25, "%uP+%uE-Cores (%uT)", num_pcores, num_ecores, num_threads)
 
 #define display_cpu_topo_hybrid_short(num_threads) \
-    printf(7, 5, "%u Threads (Hybrid)", num_threads)
+    printf_region(7, 5, 25, "%u Threads (Hybrid)", num_threads)
 
 #define display_cpu_topo_multi_socket(num_sockets, num_cores, num_threads) \
-    printf(7, 5, "%uS / %uC / %uT", num_sockets, num_cores, num_threads)
+    printf_region(7, 5, 25, "%uS / %uC / %uT", num_sockets, num_cores, num_threads)
 
 #define display_cpu_topo( num_cores, num_threads) \
-    printf(7, 5, "%u Cores %u Threads", num_cores, num_threads)
+    printf_region(7, 5, 25, "%u Cores %u Threads", num_cores, num_threads)
 
 #define display_cpu_topo_short( num_cores, num_threads) \
     printf(7, 5, "%u Cores (%uT)",  num_cores, num_threads)
 
 #define display_spec_mode(mode) \
-    prints(8,0, mode);
+    prints(8, 0, mode);
 
 #define display_spec_ddr5(freq, type, cl, cl_dec, rcd, rp, ras) \
-    printf(8,5, "%s-%u / CAS %u%s-%u-%u-%u", \
-                type, freq, cl, cl_dec?".5":"", rcd, rp, ras);
+    printf(8, 5, "%s-%u / CAS %u%s-%u-%u-%u", \
+                 type, freq, cl, cl_dec?".5":"", rcd, rp, ras);
 
 #define display_spec_ddr(freq, type, cl, cl_dec, rcd, rp, ras) \
-    printf(8,5, "%uMHz (%s-%u) CAS %u%s-%u-%u-%u", \
-                freq / 2, type, freq, cl, cl_dec?".5":"", rcd, rp, ras);
+    printf(8, 5, "%uMHz (%s-%u) CAS %u%s-%u-%u-%u", \
+                 freq / 2, type, freq, cl, cl_dec?".5":"", rcd, rp, ras);
 
 #define display_spec_sdr(freq, type, cl, rcd, rp, ras) \
-    printf(8,5, "%uMHz (%s PC%u) CAS %u-%u-%u-%u", \
-                freq, type, freq, cl, rcd, rp, ras);
+    printf(8, 5, "%uMHz (%s PC%u) CAS %u-%u-%u-%u", \
+                 freq, type, freq, cl, rcd, rp, ras);
 
 #define display_dmi_mb(sys_ma, sys_sku) \
     dmicol = prints(23, dmicol, sys_man); \
@@ -155,34 +160,19 @@ typedef enum {
     prints(3, 39, str)
 
 #define display_test_addresses(pb, pe, total) \
-    { \
-        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6); \
-        printf(4, 39, "%kB - %kB [%kB of %kB]", pb, pe, (pe) - (pb), total); \
-    }
+    printf_region(4, 39, SCREEN_MAX_COL - 5, "%kB - %kB [%kB of %kB]", pb, pe, (pe) - (pb), total)
 
 #define display_test_stage_description(...) \
-    { \
-        clear_screen_region(4, 39, 4, SCREEN_WIDTH - 6); \
-        printf(4, 39, __VA_ARGS__); \
-    }
+    printf_region(4, 39, SCREEN_MAX_COL - 5, __VA_ARGS__)
 
 #define display_test_pattern_name(str) \
-    { \
-        clear_screen_region(5, 39, 5, SCREEN_WIDTH - 1); \
-        prints(5, 39, str); \
-    }
+    prints_region(5, 39, SCREEN_MAX_COL, str); \
 
 #define display_test_pattern_value(pattern) \
-    { \
-        clear_screen_region(5, 39, 5, SCREEN_WIDTH - 1); \
-        printf(5, 39, "0x%0*x", TESTWORD_DIGITS, pattern); \
-    }
+    printf_region(5, 39, SCREEN_MAX_COL, "0x%0*x", TESTWORD_DIGITS, pattern)
 
 #define display_test_pattern_values(pattern, offset) \
-    { \
-        clear_screen_region(5, 39, 5, SCREEN_WIDTH - 1); \
-        printf(5, 39, "0x%0*x - %i", TESTWORD_DIGITS, pattern, offset); \
-    }
+    printf_region(5, 39, SCREEN_MAX_COL, "0x%0*x - %i", TESTWORD_DIGITS, pattern, offset)
 
 #define display_run_time(hours, mins, secs) \
     printf(7, 51, "%i:%02i:%02i", hours, mins, secs)
@@ -201,7 +191,7 @@ typedef enum {
 
 #define clear_message_area() \
     { \
-        clear_screen_region(ROW_MESSAGE_T, 0, ROW_MESSAGE_B, SCREEN_WIDTH - 1); \
+        clear_screen_region(ROW_MESSAGE_T, 0, ROW_MESSAGE_B, SCREEN_MAX_COL); \
         scroll_message_row = ROW_SCROLL_T - 1; \
     }
 
@@ -220,7 +210,7 @@ typedef enum {
 #define clear_footer_message() \
     { \
         set_background_colour(WHITE); \
-        clear_screen_region(ROW_FOOTER, 56, ROW_FOOTER, SCREEN_WIDTH - 1); \
+        clear_screen_region(ROW_FOOTER, 56, ROW_FOOTER, SCREEN_MAX_COL); \
         set_background_colour(BLUE);  \
     }
 
@@ -235,7 +225,7 @@ typedef enum {
     if (enable_trace) do_trace(my_cpu, __VA_ARGS__)
 
 #define display_msr_failed_flag() \
-    printc(0, SCREEN_WIDTH - 1, '*');
+    printc(0, SCREEN_MAX_COL, '*');
 
 extern int scroll_message_row;
 

--- a/app/interrupt.c
+++ b/app/interrupt.c
@@ -239,8 +239,7 @@ void interrupt(struct trap_regs *trap_regs)
         display_pinned_message(11, 7 + 3*i, "%02x", (uintptr_t)pp[i]);
     }
 
-    clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
-    prints(ROW_FOOTER, 0, "Press any key to reboot...");
+    printf_region(ROW_FOOTER, 0, SCREEN_MAX_COL, "Press any key to reboot...");
 
     while (get_key() == 0) { }
     reboot();

--- a/system/screen.c
+++ b/system/screen.c
@@ -140,6 +140,10 @@ static int lfb_offset(int row, int col, int x, int y, int bpp)
 
 static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -170,6 +174,10 @@ static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -200,6 +208,11 @@ static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb24_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -236,6 +249,10 @@ static void lfb24_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb32_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -49,22 +49,22 @@
 //------------------------------------------------------------------------------
 
 test_pattern_t test_list[NUM_TEST_PATTERNS] = {
-    // ena,  cpu, stgs, itrs, errs, description
-    { true,  ONE,    1,    6,    0, "[Address test, walking ones, no cache] "},
-    {false,  ONE,    1,    6,    0, "[Address test, own address in window]  "},
-    { true,  ONE,    2,    6,    0, "[Address test, own address + window]   "},
-    { true,  PAR,    1,    6,    0, "[Moving inversions, 1s & 0s]           "},
-    { true,  PAR,    1,    3,    0, "[Moving inversions, 8 bit pattern]     "},
-    { true,  PAR,    1,   30,    0, "[Moving inversions, random pattern]    "},
+    // ena,  cpu, stgs, itrs, errs, [description, up to 38 characters long!]
+    { true,  ONE,    1,    6,    0, "Address test, walking ones, no cache"},
+    {false,  ONE,    1,    6,    0, "Address test, own address in window"},
+    { true,  ONE,    2,    6,    0, "Address test, own address + window"},
+    { true,  PAR,    1,    6,    0, "Moving inversions, 1s & 0s"},
+    { true,  PAR,    1,    3,    0, "Moving inversions, 8 bit pattern"},
+    { true,  PAR,    1,   30,    0, "Moving inversions, random pattern"},
 #if TESTWORD_WIDTH > 32
-    { true,  PAR,    1,    3,    0, "[Moving inversions, 64 bit pattern]    "},
+    { true,  PAR,    1,    3,    0, "Moving inversions, 64 bit pattern"},
 #else
-    { true,  PAR,    1,    3,    0, "[Moving inversions, 32 bit pattern]    "},
+    { true,  PAR,    1,    3,    0, "Moving inversions, 32 bit pattern"},
 #endif
-    { true,  PAR,    1,   81,    0, "[Block move]                           "},
-    { true,  PAR,    1,   48,    0, "[Random number sequence]               "},
-    { true,  PAR,    1,    6,    0, "[Modulo 20, random pattern]            "},
-    { true,  ONE,    6,  240,    0, "[Bit fade test, 2 patterns]            "},
+    { true,  PAR,    1,   81,    0, "Block move"},
+    { true,  PAR,    1,   48,    0, "Random number sequence"},
+    { true,  PAR,    1,    6,    0, "Modulo 20, random pattern"},
+    { true,  ONE,    6,  240,    0, "Bit fade test, 2 patterns"},
 };
 
 int ticks_per_pass[NUM_PASS_TYPES];

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -22,7 +22,7 @@ typedef struct {
     int             stages;
     int             iterations;
     int             errors;
-    char            description[40];
+    char            *description;
 } test_pattern_t;
 
 extern test_pattern_t test_list[NUM_TEST_PATTERNS];


### PR DESCRIPTION
- Reduce screen writes by preventing unnecessary clear_screen_region activity.
- Do not perform Frame Buffer updates when nothing is changing.
- Don't pad test descriptions.