### PR TITLE
Enable SIMD up to SSE2 on x86_64

### DIFF
--- a/app/interrupt.c
+++ b/app/interrupt.c
@@ -84,10 +84,9 @@ static const char codes[][13] = {
 //------------------------------------------------------------------------------
 
 #ifdef __x86_64__
+
 typedef uint64_t    reg_t;
-#else
-typedef uint32_t    reg_t;
-#endif
+typedef float __m128 __attribute__ ((__vector_size__ (16)));
 
 struct trap_regs {
     reg_t   ds;
@@ -99,26 +98,46 @@ struct trap_regs {
     reg_t   dx;
     reg_t   di;
     reg_t   si;
-#ifdef __x86_64__
     reg_t   r8;
     reg_t   r9;
     reg_t   r10;
     reg_t   r11;
-#else
-    reg_t   reserved1;
-    reg_t   reserved2;
-    reg_t   sp;
-#endif
+    reg_t   xmm[16*2];
     reg_t   bp;
     reg_t   vect;
     reg_t   code;
     reg_t   ip;
     reg_t   cs;
     reg_t   flags;
-#ifdef __x86_64__
     reg_t   sp;
-#endif
 };
+
+#else
+
+typedef uint32_t    reg_t;
+
+struct trap_regs {
+    reg_t   ds;
+    reg_t   es;
+    reg_t   ss;
+    reg_t   ax;
+    reg_t   bx;
+    reg_t   cx;
+    reg_t   dx;
+    reg_t   di;
+    reg_t   si;
+    reg_t   reserved1;
+    reg_t   reserved2;
+    reg_t   sp;
+    reg_t   bp;
+    reg_t   vect;
+    reg_t   code;
+    reg_t   ip;
+    reg_t   cs;
+    reg_t   flags;
+};
+
+#endif
 
 //------------------------------------------------------------------------------
 // Public Functions

--- a/app/interrupt.c
+++ b/app/interrupt.c
@@ -86,7 +86,7 @@ static const char codes[][13] = {
 #ifdef __x86_64__
 
 typedef uint64_t    reg_t;
-typedef float __m128 __attribute__ ((__vector_size__ (16)));
+typedef float __m128 __attribute__((__vector_size__ (16), __aligned__ (16)));
 
 struct trap_regs {
     reg_t   ds;
@@ -102,7 +102,8 @@ struct trap_regs {
     reg_t   r9;
     reg_t   r10;
     reg_t   r11;
-    reg_t   xmm[16*2];
+    reg_t   r12;
+    __m128  xmm[16];
     reg_t   bp;
     reg_t   vect;
     reg_t   code;

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -251,17 +251,19 @@ flush:	movw	$KERNEL_DS, %ax
 
 	finit
 
-#if 0
 	# Enable SSE.
 
 	movq	%cr0, %rax
-	andw	$0xfffb, %ax		# clear coprocessor emulation bit
+	andw	$0xfffb, %ax	# clear coprocessor emulation bit
 	orw	$0x0002, %ax		# set coprocessor monitoring bit
 	mov	%rax, %cr0
 	movq	%cr4, %rax
 	orw	$0x0600, %ax		# set OSFXSR and OSXMMEXCPT
 	movq	%rax, %cr4
-#endif
+
+	movq	$0x1F80, %rax   # Default MXCSR value (exceptions masked, round to nearest)
+	movq	%rax, (%rsp)
+	ldmxcsr (%rsp)
 
 	# Call the dynamic linker to fix up the addresses in the GOT.
 

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -273,11 +273,11 @@ flush:	movw	$KERNEL_DS, %ax
 	testl	$0x18000000, %ecx	# Check bits 27 (OSXSAVE) and 28 (AVX)
 	jz	no_avx
 	movq	%cr4, %rax
-	orq	$(1 << 18), %rax	# Set bit 18 (OSXSAVE)
+	orl	$(1 << 18), %eax	# Set bit 18 (OSXSAVE)
 	movq	%rax, %cr4
 	xorq	%rcx, %rcx
 	xgetbv
-	orq	$0x7, %rax		# Enable x87 (bit 0), XMM (bit 1) and YMM (bit 2)
+	orb	$0x07, %al		# Enable x87 (bit 0), XMM (bit 1) and YMM (bit 2)
 	xsetbv
 
 no_avx:
@@ -445,6 +445,7 @@ int_handler:
 	movdqa	%xmm14,	0xE0(%rsp)
 	movdqa	%xmm15,	0xF0(%rsp)
 
+	pushq	%r12
 	pushq	%r11
 	pushq	%r10
 	pushq	%r9
@@ -476,6 +477,7 @@ int_handler:
 	popq	%r9
 	popq	%r10
 	popq	%r11
+	popq	%r12
 
 	movdqa  0xF0(%rsp),	%xmm15
 	movdqa  0xE0(%rsp),	%xmm14

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -254,14 +254,14 @@ flush:	movw	$KERNEL_DS, %ax
 	# Enable SSE.
 
 	movq	%cr0, %rax
-	andw	$0xfffb, %ax	# clear coprocessor emulation bit
+	andw	$0xfffb, %ax		# clear coprocessor emulation bit
 	orw	$0x0002, %ax		# set coprocessor monitoring bit
 	mov	%rax, %cr0
 	movq	%cr4, %rax
 	orw	$0x0600, %ax		# set OSFXSR and OSXMMEXCPT
 	movq	%rax, %cr4
 
-	movq	$0x1F80, %rax   # Default MXCSR value (exceptions masked, round to nearest)
+	movq	$0x1F80, %rax		# Default MXCSR value (exceptions masked, round to nearest)
 	movq	%rax, (%rsp)
 	ldmxcsr (%rsp)
 

--- a/boot/startup64.S
+++ b/boot/startup64.S
@@ -265,6 +265,24 @@ flush:	movw	$KERNEL_DS, %ax
 	movq	%rax, (%rsp)
 	ldmxcsr (%rsp)
 
+#if 0
+	# Enable AVX.
+
+	movl	$1, %eax
+	cpuid
+	testl	$0x18000000, %ecx	# Check bits 27 (OSXSAVE) and 28 (AVX)
+	jz	no_avx
+	movq	%cr4, %rax
+	orq	$(1 << 18), %rax	# Set bit 18 (OSXSAVE)
+	movq	%rax, %cr4
+	xorq	%rcx, %rcx
+	xgetbv
+	orq	$0x7, %rax		# Enable x87 (bit 0), XMM (bit 1) and YMM (bit 2)
+	xsetbv
+
+no_avx:
+#endif
+
 	# Call the dynamic linker to fix up the addresses in the GOT.
 
 	call	reloc
@@ -408,6 +426,25 @@ vec19:
 
 int_handler:
 	pushq	%rbp
+
+	subq	$256, %rsp
+	movdqa	%xmm0,	0x00(%rsp)
+	movdqa	%xmm1,	0x10(%rsp)
+	movdqa	%xmm2,	0x20(%rsp)
+	movdqa	%xmm3,	0x30(%rsp)
+	movdqa	%xmm4,	0x40(%rsp)
+	movdqa	%xmm5,	0x50(%rsp)
+	movdqa	%xmm6,	0x60(%rsp)
+	movdqa	%xmm7,	0x70(%rsp)
+	movdqa	%xmm8,	0x80(%rsp)
+	movdqa	%xmm9,	0x90(%rsp)
+	movdqa	%xmm10,	0xA0(%rsp)
+	movdqa	%xmm11,	0xB0(%rsp)
+	movdqa	%xmm12,	0xC0(%rsp)
+	movdqa	%xmm13,	0xD0(%rsp)
+	movdqa	%xmm14,	0xE0(%rsp)
+	movdqa	%xmm15,	0xF0(%rsp)
+
 	pushq	%r11
 	pushq	%r10
 	pushq	%r9
@@ -439,6 +476,25 @@ int_handler:
 	popq	%r9
 	popq	%r10
 	popq	%r11
+
+	movdqa  0xF0(%rsp),	%xmm15
+	movdqa  0xE0(%rsp),	%xmm14
+	movdqa	0xD0(%rsp),	%xmm13
+	movdqa	0xC0(%rsp),	%xmm12
+	movdqa	0xB0(%rsp),	%xmm11
+	movdqa	0xA0(%rsp),	%xmm10
+	movdqa	0x90(%rsp),	%xmm9
+	movdqa	0x80(%rsp),	%xmm8
+	movdqa	0x70(%rsp),	%xmm7
+	movdqa	0x60(%rsp),	%xmm6
+	movdqa	0x50(%rsp),	%xmm5
+	movdqa	0x40(%rsp),	%xmm4
+	movdqa	0x30(%rsp),	%xmm3
+	movdqa	0x20(%rsp),	%xmm2
+	movdqa	0x10(%rsp),	%xmm1
+	movdqa	0x00(%rsp),	%xmm0
+	addq	$256, %rsp
+
 	popq	%rbp
 	addq	$16, %rsp		# discard the vector number and error code
 	iretq

--- a/build64/Makefile
+++ b/build64/Makefile
@@ -10,9 +10,8 @@ else
   GIT_AVAILABLE = true
 endif
 
-CFLAGS = -std=gnu11 -Wall -Wextra -Wshadow -m64 -march=x86-64 -mno-mmx -mno-sse -mno-sse2 \
-         -fpic -fno-builtin -ffreestanding -fomit-frame-pointer -fno-stack-protector \
-         -fexcess-precision=standard -DARCH_BITS=64
+CFLAGS = -std=gnu11 -Wall -Wextra -Wshadow -m64 -march=x86-64 -DARCH_BITS=64 -fpic -fno-builtin \
+         -ffreestanding -fomit-frame-pointer -fno-stack-protector -fexcess-precision=standard
 
 ifeq ($(DEBUG), 1)
   CFLAGS+=-ggdb3 -DDEBUG_GDB


### PR DESCRIPTION
This remove the compiler flags preventing the use of early SIMD (MMX/SSE/SSE2) instructions.

That will be required to work on new memory tests with longer, 128-bit vector. Also, newer version of gcc seems more confused with our current parameters as I get an increasing amount of the elusive "`error: SSE register return with SSE disabled`".

As every x86_64 CPU ever released supports SSE2, this should be fine. 

PS: I'm checking if it's really necessary to add some ASM code in the boot process to set bit 9/10 in CR4 and configure MXCSR. 