### PR TITLE
loongarch: Supports 2K2000/3B6000M

### DIFF
--- a/system/imc/loongarch/loongson_la.c
+++ b/system/imc/loongarch/loongson_la.c
@@ -123,11 +123,12 @@ void get_imc_config_loongson_ddr4(void)
 {
     uint32_t val;
     uint16_t refc, loopc, div, div_mode, ref_clk;
-    uint8_t  max_mc, node_num;
+    uint8_t  max_mc, node_num, ddr_rate_factor;
     bool route_flag;
 
     imc.type  = "DDR4";
     node_num  = 1;
+    ddr_rate_factor = 4;
 
     if (strstr(cpuid_info.brand_id.str, "3C") ||
         (strstr(cpuid_info.brand_id.str, "3B6000") &&
@@ -150,6 +151,7 @@ void get_imc_config_loongson_ddr4(void)
                 strstr(cpuid_info.brand_id.str, "3B6000M")) {
         route_flag = false;
         max_mc     = 1;
+        ddr_rate_factor = 2;
     } else {
         route_flag = false;
         max_mc     = 0;
@@ -164,7 +166,7 @@ void get_imc_config_loongson_ddr4(void)
         div_mode = 0x1 << ((val >> 4) & 0x3);
         refc     = (val >> 8) & 0x1f;
         ref_clk  = (uint16_t)(((__cpucfg(0x4) * (__cpucfg(0x5) & 0xFFFF)) / ((__cpucfg(0x5) >> 16) & 0xFFFF)) / 1000000);
-        imc.freq = (ref_clk * loopc / refc / div / div_mode) * 4;
+        imc.freq = (ref_clk * loopc / refc / div / div_mode) * ddr_rate_factor;
     } else {
         imc.freq = 0;
     }


### PR DESCRIPTION
commit 414afc736a9a687573ea471af5c1e9f53e8147ed 

    loongarch: Supports fewer cache layers than L3
    
    For example: 2K2000 chip does not have L3, but has L2.
    If L2Cache is not flushed to memory, it will cause read and write data errors after cache_off.
    

commit 681d973d74672f07d144e450a8390db029602dbd

    loongarch: adjust 2K/3B6000M ddr rate factor
    

