### PR TITLE
LLVM Support for x86_64 Linux Builds

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -153,6 +153,7 @@ uintptr_t   test_addr[MAX_CPUS];
 static void run_at(uintptr_t addr, int my_cpu)
 {
     uintptr_t *new_start_addr = (uintptr_t *)(addr + startup - _start);
+    void (*fn)(void) = (void (*)())new_start_addr;
 
     if (my_cpu == 0) {
         // Copy the program code and all data except the stacks.
@@ -171,7 +172,7 @@ static void run_at(uintptr_t addr, int my_cpu)
     __asm__ __volatile__("movl %0, %%edi" : : "r" (new_start_addr));
 #endif
 
-    goto *new_start_addr;
+    fn();
 }
 
 static bool set_load_addr(uintptr_t *load_addr, size_t program_size, uintptr_t lower_limit, uintptr_t upper_limit)

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -1,8 +1,8 @@
-AS = as -64
-CC = gcc
-OBJCOPY = objcopy
+AS ?= as -64
+CC ?= cc
+OBJCOPY ?= objcopy
 
-GIT = git
+GIT ?= git
 
 ifeq ($(GIT),none)
   GIT_AVAILABLE = false

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -172,7 +172,7 @@ FORCE:
 # then link it dynamically so I have full relocation information.
 
 memtest_shared: $(OBJS) $(MS_LDS) Makefile
-	$(LD) --warn-constructors --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
+	$(LD) --warn-common -static -T $(MS_LDS) -o $@ $(OBJS) && \
 	$(LD) -shared -Bsymbolic -T $(MS_LDS) -o $@ $(OBJS)
 
 memtest_shared.bin: memtest_shared

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -25,6 +25,11 @@ else
   MS_LDS=ldscripts/memtest_shared.lds
 endif
 
+CCVER := $(shell $(CC) --version)
+ifneq (,$(findstring clang,$(CCVER)))
+  ASMEXTRAFLAGS=-mllvm -asm-macro-max-nesting-depth=64
+endif
+
 INC_DIRS = -I../../boot -I../../system -I../../system/imc -I../../system/x86 -I../../lib -I../../tests -I../../app -Iapp
 
 SYS_OBJS = system/acpi.o \
@@ -105,7 +110,7 @@ boot/x86/header.o : | ../../boot/sbat.csv
 
 boot/x86/startup.o: ../../boot/x86/startup64.S ../../boot/boot.h
 	@mkdir -p boot/x86
-	$(CC) -m64 -x assembler-with-cpp -c -I../../boot -o $@ $<
+	$(CC) -m64 -x assembler-with-cpp -c -I../../boot $(ASMEXTRAFLAGS) -o $@ $<
 
 boot/%.o: ../../boot/%.S ../../boot/boot.h app/build_version.h
 	@mkdir -p boot

--- a/build/x86_64/ldscripts/memtest_efi.lds
+++ b/build/x86_64/ldscripts/memtest_efi.lds
@@ -32,6 +32,7 @@ SECTIONS {
 		. = ALIGN(512);
 		_file_sbat_end = . ;
 	}
+	.shstrtab : { *(.shstrtab) }
 	/DISCARD/ : { *(*) }
 
 	_real_text_size  = _real_text_end  - _file_text_start;

--- a/build/x86_64/ldscripts/memtest_shared.lds
+++ b/build/x86_64/ldscripts/memtest_shared.lds
@@ -20,6 +20,7 @@ SECTIONS {
 	.hash       : { *(.hash) }
 	.gnu.hash   : { *(.gnu.hash) }
 	.dynamic    : { *(.dynamic) }
+	.shstrtab   : { *(.shstrtab) }
 
 	.rela.text    : { *(.rela.text   .rela.text.*) }
 	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) }

--- a/build/x86_64/ldscripts/memtest_shared.lds
+++ b/build/x86_64/ldscripts/memtest_shared.lds
@@ -25,19 +25,19 @@ SECTIONS {
 	.rela.text    : { *(.rela.text   .rela.text.*) }
 	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) }
 	.rela.data    : { *(.rela.data   .rela.data.*) }
-	.rela.got     : { *(.rela.got    .rela.got.*) }
 	.rela.plt     : { *(.rela.plt    .rela.plt.*) }
+	.rela.got     : { *(.rela.got    .rela.got.*) }
+	.got : {
+		*(.got.plt)
+		*(.got)
+		_edata = . ;
+	}
 
 	. = ALIGN(4);
 	.data : {
 		 _data = .;
 		*(.data)
 		*(.data.*)
-	}
-	.got : {
-		*(.got.plt)
-		*(.got)
-		_edata = . ;
 	}
 	. = ALIGN(4);
 	.bss : {

--- a/build/x86_64/ldscripts/memtest_shared.lds
+++ b/build/x86_64/ldscripts/memtest_shared.lds
@@ -32,6 +32,7 @@ SECTIONS {
 		*(.got)
 		_edata = . ;
 	}
+	.rela.dyn     : { *(.rela.dyn    .rela.dyn.*) }
 
 	. = ALIGN(4);
 	.data : {

--- a/lib/string.c
+++ b/lib/string.c
@@ -53,7 +53,7 @@ void *memmove(void *dest, const void *src, size_t n)
     return dest;
 }
 
-#if (defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if (defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__llvm__))
 
 void *memcpy (void *dest, const void *src, size_t len)
 {

--- a/lib/string.h
+++ b/lib/string.h
@@ -36,7 +36,7 @@ static inline int memcmp(const void *s1, const void *s2, size_t n)
  * not overlap.
  * void *memcpy(void *dst, const void *src, size_t n);
  */
-#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__llvm__))
     #define memcpy(d, s, n) __builtin_memcpy((d), (s), (n))
 #else
     void *memcpy (void *dest, const void *src, size_t len);
@@ -54,7 +54,7 @@ void *memmove(void *dest, const void *src, size_t n);
  * value c.
  * void *memset(void *s, int c, size_t n);
  */
-#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64))
+#if !(defined(DEBUG_GDB) || defined(__loongarch_lp64) || defined(__llvm__))
     #define memset(s, c, n) __builtin_memset((s), (c), (n))
 #else
     void *memset (void *dest, int val, size_t len);


### PR DESCRIPTION
This PR contains eight small patches which allow Memtest86+ to be built with clang and lld. Everything works, as far as I can tell.