### PR TITLE
imc: Enable support for AMD Cezanne (Zen 3 APU)

### DIFF
--- a/system/x86/cpuinfo.c
+++ b/system/x86/cpuinfo.c
@@ -350,7 +350,7 @@ static void determine_imc(void)
                 imc.family = IMC_K19_RBT; // Zen3+ (Family 19h - Rembrandt FP7 & AM5 FTV)
                 break;
               case 5:
-                imc.family = IMC_K19_CZN; // Zen3 APU (Family 19h - Cezanne FP6)
+                imc.family = IMC_K19_CZN; // Zen3 APU (Family 19h - Cezanne FP6/AM4)
                 break;
               case 6:
                 imc.family = IMC_K19_RPL; // Zen4 (Family 19h - Raphael AM5)

--- a/system/x86/memctrl.c
+++ b/system/x86/memctrl.c
@@ -35,6 +35,7 @@ void memctrl_init(void)
     switch(imc.family) {
       case IMC_K17:
       case IMC_K19_VRM:
+      case IMC_K19_CZN:
       case IMC_K19_RPL:
       case IMC_K19_RBT:
       case IMC_K19_PHX:


### PR DESCRIPTION
Tested with Ryzen 7 5700G (AM4), it matches the manual configuration in the firmware.
![imc-czn-r7-5700g](https://github.com/user-attachments/assets/e4d0d0fd-ceb9-4f71-a8e5-359e3eaeec53)
