### PR TITLE
Added newlines and full draws to serial output for automation

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -111,6 +111,7 @@ bool            enable_tty         = false;
 uintptr_t       tty_address        = 0x3F8;             // Legacy IO or MMIO Address accepted
 int             tty_baud_rate      = 115200;
 int             tty_update_period  = 2;                 // Update TTY every 2 seconds (default)
+bool            tty_new_line       = false;
 
 uint32_t        tty_mmio_ref_clk   = UART_REF_CLK_MMIO; // Reference clock for MMIO (in Hz)
 int             tty_mmio_stride    = 4;                 // Stride for MMIO (register width in bytes)
@@ -207,6 +208,8 @@ static void parse_option(const char *option, const char *params)
 
     if (strncmp(option, "console", 8) == 0) {
         parse_serial_params(params);
+    } else if (strncmp(option, "newline",7)){
+        tty_new_line = true;
     } else if (strncmp(option, "cpuseqmode", 11) == 0) {
         if (strncmp(params, "par", 4) == 0) {
             cpu_mode = PAR;

--- a/app/config.h
+++ b/app/config.h
@@ -72,6 +72,7 @@ extern power_save_t power_save;
 extern uintptr_t    tty_address;
 extern int          tty_baud_rate;
 extern int          tty_update_period;
+extern bool         tty_new_line;
 
 extern uint32_t     tty_mmio_ref_clk;
 extern int          tty_mmio_stride;

--- a/system/serial.c
+++ b/system/serial.c
@@ -159,7 +159,17 @@ void tty_init(void)
     tty_disable_cursor();
 }
 
-void tty_send_region(int start_row, int start_col, int end_row, int end_col)
+void tty_send_region(int start_row, int start_col, int end_row, int end_col){
+    if(tty_new_line){
+        tty_send_region_actual(0,0,24,79);
+        serial_echo_print("\n");
+    }
+    else {
+        tty_send_region_actual(start_row, start_col, end_row, end_col);
+    }
+}
+
+void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col)
 {
     char p[SCREEN_WIDTH+1];
     uint8_t ch;

--- a/system/serial.c
+++ b/system/serial.c
@@ -171,6 +171,16 @@ void tty_send_region(int start_row, int start_col, int end_row, int end_col){
 
 void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col)
 {
+    if (tty_new_line) {
+        tty_send_region_actual(0,0,24,79);
+        serial_echo_print("\n");
+    } else {
+        tty_send_region_actual(start_row, start_col, end_row, end_col);
+    }
+}
+
+void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col)
+{
     char p[SCREEN_WIDTH+1];
     uint8_t ch;
     int pos = 0;

--- a/system/serial.h
+++ b/system/serial.h
@@ -179,6 +179,8 @@ void tty_print(int y, int x, const char *p);
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col);
 
+void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col);
+
 char tty_get_key(void);
 
 #endif /* _SERIAL_REG_H */


### PR DESCRIPTION
The current way of logging using the cursor doesn't play too nicely with software that listens for new lines and makes it so that the serial output cannot be logged to any sort of file in a reliable way.

This code change allows for the serial output based on a new "newline" boot param to:
1. Redraw the whole frame on each output, something needed for reliable reading of the output frame.
2. Output a newline at the end of the redraw.

The change is pretty simple and should not interfere with any existing functionality for serial devices, but will make the serial output a lot easier to parse for automation.