### PR TITLE
added support for new lines in serial output

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ recognised:
       * mmio16 = 16-bit MMIO
       * mmio32 = 32-bit MMIO
     * and *y* is the MMIO address in hex. with `0x` prefix (eg: 0xFEDC9000)
+  * newline
+    * modifies the console to print a newline after every change to the frame buffer
+      * useful in logging over serial where an escape or newline is needed
+    * only used when using console/serial output
 
 ## Keyboard Selection
 

--- a/app/config.c
+++ b/app/config.c
@@ -111,6 +111,7 @@ bool            enable_tty         = false;
 uintptr_t       tty_address        = 0x3F8;             // Legacy IO or MMIO Address accepted
 int             tty_baud_rate      = 115200;
 int             tty_update_period  = 2;                 // Update TTY every 2 seconds (default)
+bool            tty_new_line       = false;
 
 uint32_t        tty_mmio_ref_clk   = UART_REF_CLK_MMIO; // Reference clock for MMIO (in Hz)
 int             tty_mmio_stride    = 4;                 // Stride for MMIO (register width in bytes)
@@ -207,6 +208,8 @@ static void parse_option(const char *option, const char *params)
 
     if (strncmp(option, "console", 8) == 0) {
         parse_serial_params(params);
+    } else if (strncmp(option, "newline", 7) == 0) {
+        tty_new_line = true;
     } else if (strncmp(option, "cpuseqmode", 11) == 0) {
         if (strncmp(params, "par", 4) == 0) {
             cpu_mode = PAR;

--- a/app/config.h
+++ b/app/config.h
@@ -72,6 +72,7 @@ extern power_save_t power_save;
 extern uintptr_t    tty_address;
 extern int          tty_baud_rate;
 extern int          tty_update_period;
+extern bool         tty_new_line;
 
 extern uint32_t     tty_mmio_ref_clk;
 extern int          tty_mmio_stride;

--- a/system/serial.c
+++ b/system/serial.c
@@ -161,11 +161,9 @@ void tty_init(void)
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col)
 {
-    if (tty_new_line) {
-        tty_send_region_actual(0,0,24,79);
+    tty_send_region_actual(start_row, start_col, end_row, end_col);
+    if (tty_new_line) {  
         serial_echo_print("\n");
-    } else {
-        tty_send_region_actual(start_row, start_col, end_row, end_col);
     }
 }
 

--- a/system/serial.c
+++ b/system/serial.c
@@ -161,6 +161,16 @@ void tty_init(void)
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col)
 {
+    if (tty_new_line) {
+        tty_send_region_actual(0,0,24,79);
+        serial_echo_print("\n");
+    } else {
+        tty_send_region_actual(start_row, start_col, end_row, end_col);
+    }
+}
+
+void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col)
+{
     char p[SCREEN_WIDTH+1];
     uint8_t ch;
     int pos = 0;

--- a/system/serial.h
+++ b/system/serial.h
@@ -179,6 +179,8 @@ void tty_print(int y, int x, const char *p);
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col);
 
+void tty_send_region_actual(int start_row, int start_col, int end_row, int end_col);
+
 char tty_get_key(void);
 
 #endif /* _SERIAL_REG_H */


### PR DESCRIPTION
The current way of logging using the cursor to send V100 commands of the framebuffer doesn't play too nicely with software that listens for new lines and makes it so that the serial output cannot be logged to any sort of file in a reliable way.

This code change allows for the serial output based on a new "newline" boot param to output a newline at the end of every redraw to serial.

The change is pretty simple in how it is written and should not interfere with any existing functionality for serial devices (the code for tty_send_region remains unchanged), but will make the serial output a lot easier to parse for automation purposes. Having a new line adds a clear delim to any parsers down the road.

The code does not change the actual output (still just the frame buffer) but does allow for parsing since with the newline you can now regex what you need from each update sent and deliminated with a newline char.

An example of where this has been brought up before in #389 and https://github.com/memtest86plus/memtest86plus/discussions/360#discussioncomment-8764727