### PR TITLE
Update Intel i801 PCI device IDs list

### DIFF
--- a/system/x86/i2c.c
+++ b/system/x86/i2c.c
@@ -172,7 +172,7 @@ static const uint16_t intel_ich5_dids[] =
     0x51A3,  // Alder Lake-P (PCH)
     0x54A3,  // Alder Lake-M (PCH)
     0x7A23,  // Raptor Lake-S (PCH)
-    //0x7E22,  // Meteor Lake-P (SOC)
+    0x7E22,  // Meteor Lake-P (SOC)
     //0xAE22,  // Meteor Lake-S (PCH)
     0x7F23,  // Arrow Lake-S (PCH)
     //0x5796,  // Birch Stream (SOC)

--- a/system/x86/i2c.c
+++ b/system/x86/i2c.c
@@ -173,8 +173,13 @@ static const uint16_t intel_ich5_dids[] =
     0x54A3,  // Alder Lake-M (PCH)
     0x7A23,  // Raptor Lake-S (PCH)
     //0x7E22,  // Meteor Lake-P (SOC)
+    //0xAE22,  // Meteor Lake-S (PCH)
     0x7F23,  // Arrow Lake-S (PCH)
+    //0x5796,  // Birch Stream (SOC)
+    //0x7722,  // Arrow Lake-H (SOC)
     //0xA822,  // Lunar Lake
+    //0xE322,  // Panther Lake-H (SOC)
+    //0xE422,  // Panther Lake-P (SOC)
 };
 
 static bool find_in_did_array(uint16_t did, const uint16_t * ids, unsigned int size)


### PR DESCRIPTION
Here's a mechanical synchronization of the list of SMBus controller PCI IDs from https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/i2c/busses/i2c-i801.c as of 6.16 / 6.17rc1 . The entries are disabled until a successful test on our side.
For some reason, the Linux driver does not contain the Lunar Lake SMBus controller PCI ID, namely `0xa822`, which is both on the open Internet and in https://github.com/coreboot/coreboot/blob/master/src/include/device/pci_ids.h with a `LNL` name.
The other discrepancy I noticed between our list and the ones in Linux and Coreboot is `0x5ad4` for Broxton platforms: it isn't in our list. ISTR that there's something about this one, but I don't remember what...