### PR TITLE
Optimize screen writes

### DIFF
--- a/system/screen.c
+++ b/system/screen.c
@@ -140,6 +140,10 @@ static int lfb_offset(int row, int col, int x, int y, int bpp)
 
 static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -170,6 +174,10 @@ static void lfb8_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -200,6 +208,11 @@ static void lfb16_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb24_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 
@@ -236,6 +249,10 @@ static void lfb24_put_char(int row, int col, uint8_t ch, uint8_t attr)
 
 static void lfb32_put_char(int row, int col, uint8_t ch, uint8_t attr)
 {
+    if (shadow_buffer[row][col].ch   == ch &&
+        shadow_buffer[row][col].attr == attr)
+        return;
+
     shadow_buffer[row][col].ch   = ch;
     shadow_buffer[row][col].attr = attr;
 


### PR DESCRIPTION
I'd like to revive the two screen writes optimization patches from 01e3. This is the easiest one; the other one is currently 52d8bde0d6ec3750db2f86eca777e3dbf1306402 on the `optimizations` branch. Besides reducing flicker, each patch was shown to save seconds on the tests which are the most screen-write-intensive - basically, more RAM testing, less CPU waste.

AFAICT, the only situation this patch might have a visible impact is an external corruption of the framebuffer... which is an area of memory we don't test anyway, and I'd argue that if there really is such memory corruption, we want to make it more visible.

Of course, I can add the other patch to the same PR, but I think that this one could go separately, before the upcoming release, without invalidating ongoing testing rounds.