### PR TITLE
Unhide SMBUS device to allow SPD reading on early Intel's ICH SB

### DIFF
--- a/system/hwquirks.c
+++ b/system/hwquirks.c
@@ -153,7 +153,6 @@ static void unhide_ich_0_5(void)
     smb_ctrl_reg = pci_config_read32(0, 0x1F, 0x00, 0xF0);
     smb_ctrl_reg &= ~(1 << 19);
     pci_config_write32(0, 0x1F, 0x00, 0xF0, smb_ctrl_reg);
-
 }
 
 static void unhide_asus_smbus(void)
@@ -308,21 +307,21 @@ void quirks_init(void)
 
         switch(sb_lpc_did)
         {
-            case PCI_SB_ICH:
-            case PCI_SB_ICH1:
-            case PCI_SB_ICH2:
-            case PCI_SB_ICH2M:
-            case PCI_SB_ICH3:
-            case PCI_SB_ICH3M:
-            case PCI_SB_ICH4:
-            case PCI_SB_ICH4M:
-            case PCI_SB_ICH5:
-            case PCI_SB_6300ESB:
+            case PCI_DID_LPC_ICH:
+            case PCI_DID_LPC_ICH1:
+            case PCI_DID_LPC_ICH2:
+            case PCI_DID_LPC_ICH2M:
+            case PCI_DID_LPC_ICH3:
+            case PCI_DID_LPC_ICH3M:
+            case PCI_DID_LPC_ICH4:
+            case PCI_DID_LPC_ICH4M:
+            case PCI_DID_LPC_ICH5:
+            case PCI_DID_LPC_6300ESB:
                 quirk.id      = QUIRK_UNHIDE_ICH05;
                 quirk.type   |= QUIRK_TYPE_SMBUS;
                 quirk.process = unhide_ich_0_5;
                 break;
-            case PCI_SB_ICH6M:
+            case PCI_DID_LPC_ICH6M:
                 if (root_subvid == PCI_VID_DELL && root_subdid == 0x0182) { // Dell D620
                     quirk.id      = QUIRK_UNHIDE_ASUS_SMBUS;
                     quirk.type   |= QUIRK_TYPE_SMBUS;

--- a/system/hwquirks.h
+++ b/system/hwquirks.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2004-2022 Sam Demeulemeester
+// Copyright (C) 2004-2025 Sam Demeulemeester
 #ifndef _QUIRK_H_
 #define _QUIRK_H_
 /**
@@ -30,7 +30,9 @@ typedef enum {
     QUIRK_K8_REVFG_TEMP,
     QUIRK_AMD_ERRATA_319,
     QUIRK_VIA_VP3,
-    QUIRK_LOONGSON7A00_EHCI_WORKARD
+    QUIRK_LOONGSON7A00_EHCI_WORKARD,
+    QUIRK_UNHIDE_ICH05,
+    QUIRK_UNHIDE_ASUS_SMBUS
 } quirk_id_t;
 
 typedef struct {

--- a/system/hwquirks.h
+++ b/system/hwquirks.h
@@ -32,7 +32,7 @@ typedef enum {
     QUIRK_VIA_VP3,
     QUIRK_LOONGSON7A00_EHCI_WORKARD,
     QUIRK_UNHIDE_ICH05,
-    QUIRK_UNHIDE_ASUS_SMBUS
+    QUIRK_UNHIDE_ASUS_SMBUS,
 } quirk_id_t;
 
 typedef struct {

--- a/system/pci.h
+++ b/system/pci.h
@@ -40,21 +40,21 @@
 #define PCI_VID_INTEL        0x8086
 
 /* Intel Southbridge ISA/LPC (Device 0x1F, Function 0x00) DIDs */
-#define PCI_SB_ICH           0x2410
-#define PCI_SB_ICH1          0x2420
-#define PCI_SB_ICH2          0x2440
-#define PCI_SB_ICH2M         0x244C
-#define PCI_SB_ICH3          0x2480
-#define PCI_SB_ICH3M         0x248C
-#define PCI_SB_ICH4          0x24C0
-#define PCI_SB_ICH4M         0x24CC
-#define PCI_SB_ICH5          0x24D0
-#define PCI_SB_6300ESB       0x25A1
-#define PCI_SB_ICH5S         0x25A1
-#define PCI_SB_ICH6          0x2640
-#define PCI_SB_ICH6M         0x2641
-#define PCI_SB_ICH7          0x27B8
-#define PCI_SB_ICH7M         0x27B9
+#define PCI_DID_LPC_ICH      0x2410
+#define PCI_DID_LPC_ICH1     0x2420
+#define PCI_DID_LPC_ICH2     0x2440
+#define PCI_DID_LPC_ICH2M    0x244C
+#define PCI_DID_LPC_ICH3     0x2480
+#define PCI_DID_LPC_ICH3M    0x248C
+#define PCI_DID_LPC_ICH4     0x24C0
+#define PCI_DID_LPC_ICH4M    0x24CC
+#define PCI_DID_LPC_ICH5     0x24D0
+#define PCI_DID_LPC_6300ESB  0x25A1
+#define PCI_DID_LPC_ICH5S    0x25A1
+#define PCI_DID_LPC_ICH6     0x2640
+#define PCI_DID_LPC_ICH6M    0x2641
+#define PCI_DID_LPC_ICH7     0x27B8
+#define PCI_DID_LPC_ICH7M    0x27B9
 
 /**
  * Initialises the PCI access support.

--- a/system/pci.h
+++ b/system/pci.h
@@ -13,6 +13,10 @@
 
 #include <stdint.h>
 
+#define PCI_MAX_BUS     256
+#define PCI_MAX_DEV     32
+#define PCI_MAX_FUNC    8
+
 #define PCI_VID_REG          0x00
 #define PCI_DID_REG          0x02
 #define PCI_SUB_VID_REG      0x2C
@@ -22,7 +26,9 @@
 #define PCI_VID_LOONGSON     0x0014
 #define PCI_VID_ATI          0x1002
 #define PCI_VID_AMD          0x1022
+#define PCI_VID_DELL         0x1028
 #define PCI_VID_SIS          0x1039
+#define PCI_VID_HP           0x103C
 #define PCI_VID_ASUS         0x1043
 #define PCI_VID_EFAR         0x1055
 #define PCI_VID_ALI          0x10B9
@@ -33,9 +39,22 @@
 #define PCI_VID_HYGON        0x1D94
 #define PCI_VID_INTEL        0x8086
 
-#define PCI_MAX_BUS     256
-#define PCI_MAX_DEV     32
-#define PCI_MAX_FUNC    8
+/* Intel Southbridge ISA/LPC (Device 0x1F, Function 0x00) DIDs */
+#define PCI_SB_ICH           0x2410
+#define PCI_SB_ICH1          0x2420
+#define PCI_SB_ICH2          0x2440
+#define PCI_SB_ICH2M         0x244C
+#define PCI_SB_ICH3          0x2480
+#define PCI_SB_ICH3M         0x248C
+#define PCI_SB_ICH4          0x24C0
+#define PCI_SB_ICH4M         0x24CC
+#define PCI_SB_ICH5          0x24D0
+#define PCI_SB_6300ESB       0x25A1
+#define PCI_SB_ICH5S         0x25A1
+#define PCI_SB_ICH6          0x2640
+#define PCI_SB_ICH6M         0x2641
+#define PCI_SB_ICH7          0x27B8
+#define PCI_SB_ICH7M         0x27B9
 
 /**
  * Initialises the PCI access support.


### PR DESCRIPTION
Add quirks for ICH0-5 (SMbus Unhide)