### PR TITLE
Add support for AMD Zen5 Granite Ridge (GRG) ECC polling

### DIFF
--- a/system/msr.h
+++ b/system/msr.h
@@ -8,7 +8,7 @@
  *
  *//*
  * Copyright (C) 2020-2022 Martin Whitaker.
- * Copyright (C) 2020-2023 Sam Demeulemeester.
+ * Copyright (C) 2020-2025 Sam Demeulemeester.
  */
 
 #define MSR_PLATFORM_INFO               0xce
@@ -31,9 +31,12 @@
 
 #define MSR_AMD64_NB_CFG                0xc001001f
 #define MSR_AMD64_COFVID_STATUS         0xc0010071
-#define MSR_AMD64_UMC_MCA_CTRL          0xc00020f0
-#define MSR_AMD64_UMC_MCA_STATUS        0xc00020f1
-#define MSR_AMD64_UMC_MCA_ADDR          0xc00020f2
+#define MSR_AMD64_K17_UMC_MCA_CTRL      0xc00020f0
+#define MSR_AMD64_K17_UMC_MCA_STATUS    0xc00020f1
+#define MSR_AMD64_K17_UMC_MCA_ADDR      0xc00020f2
+#define MSR_AMD64_K1A_UMC_MCA_CTRL      0xc0002150
+#define MSR_AMD64_K1A_UMC_MCA_STATUS    0xc0002151
+#define MSR_AMD64_K1A_UMC_MCA_ADDR      0xc0002152
 #define MSR_AMD64_HW_CONF               0xc0010015
 
 #define MSR_VIA_TEMP_C7                 0x1169

--- a/system/x86/memctrl.c
+++ b/system/x86/memctrl.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2004-2023 Sam Demeulemeester
+// Copyright (C) 2004-2025 Sam Demeulemeester
 //
 // ------------------------
 //
@@ -84,6 +84,7 @@ void memctrl_poll_ecc(void)
       case IMC_K19_VRM:
       case IMC_K19_RPL:
       case IMC_K19_RBT:
+      case IMC_K1A_GRG:
         poll_ecc_amd_zen(true);
         break;
       default:


### PR DESCRIPTION
Also fix an issue with Rembrandt ECC polling where only half of the channels where polled.