### PR TITLE
Recognise VT52/VT100/VT220 key escape sequences on serial console

### DIFF
--- a/system/keyboard.c
+++ b/system/keyboard.c
@@ -240,17 +240,17 @@ static char get_vt220_sequence1(void)
       case 'S':
         return '4';  // VT100/VT220 PF4 (F4 in terminal emulators)
       case 'T':
-        return '5';  // VT100/VT220 PF5 (F5 in terminal emulators)
+        return '5';  // F5 in some terminal emulators
       case 'U':
-        return '6';  // VT100/VT220 PF6 (F6 in terminal emulators)
+        return '6';  // F6 in some terminal emulators
       case 'V':
-        return '7';  // VT100/VT220 PF7 (F7 in terminal emulators)
+        return '7';  // F7 in some terminal emulators
       case 'W':
-        return '8';  // VT100/VT220 PF8 (F8 in terminal emulators)
+        return '8';  // F8 in some terminal emulators
       case 'X':
-        return '9';  // VT100/VT220 PF9 (F9 in terminal emulators)
+        return '9';  // F9 in some terminal emulators
       case 'Y':
-        return '0';  // VT100/VT220 PF10 (F10 in terminal emulators)
+        return '0';  // F10 in some terminal emulators
       default:
         return '\0'; // unrecognised key
         break;

--- a/system/keyboard.c
+++ b/system/keyboard.c
@@ -239,6 +239,18 @@ static char get_vt220_sequence1(void)
         return '3';  // VT100/VT220 PF3 (F3 in terminal emulators)
       case 'S':
         return '4';  // VT100/VT220 PF4 (F4 in terminal emulators)
+      case 'T':
+        return '5';  // VT100/VT220 PF5 (F5 in terminal emulators)
+      case 'U':
+        return '6';  // VT100/VT220 PF6 (F6 in terminal emulators)
+      case 'V':
+        return '7';  // VT100/VT220 PF7 (F7 in terminal emulators)
+      case 'W':
+        return '8';  // VT100/VT220 PF8 (F8 in terminal emulators)
+      case 'X':
+        return '9';  // VT100/VT220 PF9 (F9 in terminal emulators)
+      case 'Y':
+        return '0';  // VT100/VT220 PF10 (F10 in terminal emulators)
       default:
         return '\0'; // unrecognised key
         break;
@@ -274,6 +286,14 @@ static char get_vt220_sequence2(void)
     switch (ch1) {
       case '1':
         switch (ch2) {
+          case '1':
+            ch1 = '1'; break;  // F1 in terminal emulators
+          case '2':
+            ch1 = '2'; break;  // F2 in terminal emulators
+          case '3':
+            ch1 = '3'; break;  // F3 in terminal emulators
+          case '4':
+            ch1 = '4'; break;  // F4 in terminal emulators
           case '5':
             ch1 = '5'; break;  // F5 in terminal emulators
           case '7':
@@ -353,6 +373,20 @@ void keyboard_init(void)
 
 char get_key(void)
 {
+    if (enable_tty) {
+        char c = tty_get_char(0);
+        switch (c) {
+          case '\0':
+            break;
+          case '\r':
+            return '\n';
+          case ESC:
+            return get_tty_special_key();
+          default:
+            return c;
+        }
+    }
+
     if (keyboard_types & KT_USB) {
         uint8_t c = get_usb_keycode();
         if (c > 0 && c < sizeof(usb_hid_keymap)) {
@@ -385,20 +419,6 @@ char get_key(void)
             escaped = (c == 0xe0);
 
             // Ignore keys we don't recognise and key up codes
-        }
-    }
-
-    if (enable_tty) {
-        char c = tty_get_char(0);
-        switch (c) {
-          case '\0':
-            break;
-          case '\r':
-            return '\n';
-          case ESC:
-            return get_tty_special_key();
-          default:
-            return c;
         }
     }
 

--- a/system/keyboard.h
+++ b/system/keyboard.h
@@ -40,7 +40,8 @@ void keyboard_init(void);
 /**
  * Checks if a key has been pressed and returns the primary ASCII character
  * corresponding to that key if so, otherwise returns the null character.
- * F1 to F10 are mapped to the corresponding decimal digit (F10 -> 0). All
+ * F1 to F10 are mapped to the corresponding decimal digit (F10 -> 0). The
+ * Up, Down, Left, Right cursor keys are mapped to 'u', 'd', 'l', 'r'. All
  * other keys that don't have a corresponding ASCII character are ignored.
  * Characters are only returned for key presses, not key releases. A US
  * keyboard layout is assumed (because we can't easily do anything else).

--- a/system/serial.c
+++ b/system/serial.c
@@ -65,7 +65,7 @@ static void serial_wait_for_xmit(struct serial_port *port)
     } while ((lsr & BOTH_EMPTY) != BOTH_EMPTY);
 }
 
-void serial_echo_print(const char *p)
+static void serial_echo_print(const char *p)
 {
     struct serial_port *port = &console_serial;
 
@@ -81,7 +81,7 @@ void serial_echo_print(const char *p)
     }
 }
 
-void tty_goto(int y, int x)
+static void tty_goto(int y, int x)
 {
     static char s[3];
 

--- a/system/serial.h
+++ b/system/serial.h
@@ -7,7 +7,7 @@
  * display via Serial/UART.
  *
  *//*
- * Copyright (C) 2004-2023 Sam Demeulemeester.
+ * Copyright (C) 2004-2025 Sam Demeulemeester.
  */
 
 #define SERIAL_DEFAULT_BITS     8
@@ -26,6 +26,7 @@ struct serial_port {
     int parity;
     int bits;
     int baudrate;
+    int frame_time;
     int reg_width;
     int refclk;
     uintptr_t base_addr;
@@ -179,6 +180,6 @@ void tty_print(int y, int x, const char *p);
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col);
 
-char tty_get_key(void);
+char tty_get_char(int max_wait_frames);
 
 #endif /* _SERIAL_REG_H */


### PR DESCRIPTION
As discussed in PR #546, this is an alternative solution that recognises the escape sequences for VT52, VT100, and VT220 special keys and maps the function and cursor key sequences to the appropriate ASCII characters.