### PR TITLE
TTY redraw fixes

### DIFF
--- a/app/config.c
+++ b/app/config.c
@@ -798,9 +798,16 @@ static void cpu_selection_menu(void)
 
     display_cpu_selection(display_offset);
 
+    bool tty_update = enable_tty;
     bool exit_menu = false;
     while (!exit_menu) {
         bool changed = false;
+
+        if (tty_update) {
+            tty_send_region(POP_REGION);
+        }
+        tty_update = enable_tty;
+
         switch (get_key()) {
           case '1':
             changed = set_all_cpus(false, display_offset);
@@ -839,6 +846,7 @@ static void cpu_selection_menu(void)
             break;
           default:
             usleep(1000);
+            tty_update = false;
             break;
         }
         if (changed) {

--- a/app/display.c
+++ b/app/display.c
@@ -229,6 +229,10 @@ void display_init(void)
     }
 
     scroll_message_row = ROW_SCROLL_T;
+
+    if (enable_tty) {
+        tty_full_redraw();
+    }
 }
 
 void display_cpu_topology(void)
@@ -525,6 +529,9 @@ void set_scroll_lock(bool enabled)
     set_foreground_colour(palette.footer_foreground);
     prints(ROW_FOOTER, 48, scroll_lock ? "unlock" : "lock  ");
     set_foreground_colour(palette.foreground);
+    if (enable_tty) {
+        tty_footer_redraw();
+    }
 }
 
 void toggle_scroll_lock(void)
@@ -548,6 +555,9 @@ void scroll(void)
         scroll_wait = false;
         clear_footer_message();
         scroll_screen_region(ROW_SCROLL_T, 0, ROW_SCROLL_B, SCREEN_WIDTH - 1);
+        if (enable_tty) {
+            tty_scroll_redraw();
+        }
     }
 }
 

--- a/app/display.h
+++ b/app/display.h
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 
 #include "screen.h"
+#include "serial.h"
 
 #include "print.h"
 #include "string.h"
@@ -212,6 +213,9 @@ typedef enum {
     { \
         clear_screen_region(ROW_MESSAGE_T, 0, ROW_MESSAGE_B, SCREEN_WIDTH - 1); \
         scroll_message_row = ROW_SCROLL_T - 1; \
+        if (enable_tty) { \
+            tty_message_redraw(); \
+        } \
     }
 
 #define display_pinned_message(row, col, ...) \
@@ -221,16 +225,29 @@ typedef enum {
     printf(scroll_message_row, col, __VA_ARGS__)
 
 #define display_notice(str) \
-    prints(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - strlen(str)) / 2, str)
+    { \
+        prints(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - strlen(str)) / 2, str); \
+        if (enable_tty) { \
+            tty_message_redraw(); \
+        } \
+    }
 
 #define display_notice_with_args(length, ...) \
-    printf(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - length) / 2, __VA_ARGS__)
+    { \
+        printf(ROW_MESSAGE_T + 8, (SCREEN_WIDTH - length) / 2, __VA_ARGS__); \
+        if (enable_tty) { \
+            tty_message_redraw(); \
+        } \
+    }
 
 #define clear_footer_message() \
     { \
         set_background_colour(palette.foreground); \
         clear_screen_region(ROW_FOOTER, 56, ROW_FOOTER, SCREEN_WIDTH - 1); \
         set_background_colour(palette.background);  \
+        if (enable_tty) { \
+            tty_footer_redraw(); \
+        } \
     }
 
 #define display_footer_message(str) \
@@ -238,6 +255,9 @@ typedef enum {
         set_foreground_colour(palette.footer_foreground);  \
         prints(ROW_FOOTER, 56, str);  \
         set_foreground_colour(palette.footer_background); \
+        if (enable_tty) { \
+            tty_footer_redraw(); \
+        } \
     }
 
 #define trace(my_cpu, ...) \

--- a/app/loongarch/interrupt.c
+++ b/app/loongarch/interrupt.c
@@ -11,7 +11,10 @@
 #include "hwctrl.h"
 #include "screen.h"
 #include "keyboard.h"
+#include "serial.h"
 #include "smp.h"
+
+#include "config.h"
 #include "display.h"
 
 #include <larchintrin.h>
@@ -226,6 +229,10 @@ void interrupt(struct system_context *system_context)
 
     clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
     prints(ROW_FOOTER, 0, "Press any key to reboot...");
+
+    if (enable_tty) {
+        tty_full_redraw();
+    }
 
     while (get_key() == 0) { }
     reboot();

--- a/app/x86/interrupt.c
+++ b/app/x86/interrupt.c
@@ -14,8 +14,10 @@
 #include "hwctrl.h"
 #include "keyboard.h"
 #include "screen.h"
+#include "serial.h"
 #include "smp.h"
 
+#include "config.h"
 #include "error.h"
 #include "display.h"
 
@@ -241,6 +243,10 @@ void interrupt(struct trap_regs *trap_regs)
 
     clear_screen_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
     prints(ROW_FOOTER, 0, "Press any key to reboot...");
+
+    if (enable_tty) {
+        tty_full_redraw();
+    }
 
     while (get_key() == 0) { }
     reboot();

--- a/system/serial.h
+++ b/system/serial.h
@@ -161,6 +161,15 @@ struct serial_port {
 #define tty_error_redraw() \
     tty_send_region(10, 0, 23, 79);
 
+#define tty_footer_redraw() \
+    tty_send_region(ROW_FOOTER, 0, ROW_FOOTER, SCREEN_WIDTH - 1);
+
+#define tty_message_redraw() \
+    tty_send_region(ROW_MESSAGE_T, 0, ROW_MESSAGE_B, SCREEN_WIDTH - 1);
+
+#define tty_scroll_redraw() \
+    tty_send_region(ROW_SCROLL_T, 0, ROW_SCROLL_B, SCREEN_WIDTH - 1);
+
 #define tty_normal() \
     serial_echo_print(TTY_NORMAL);
 


### PR DESCRIPTION
Several fixes to make sure the TTY screen is updated correctly before and after tests are running, and in interrupt case.