### PR TITLE
[RFC] Add screen rotation quirks

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -214,6 +214,10 @@ static void global_init(void)
 
     hwctrl_init();
 
+    pci_init();
+
+    quirks_init();
+
     screen_init();
 
     cpuinfo_init();
@@ -221,10 +225,6 @@ static void global_init(void)
     pmem_init();
 
     heap_init();
-
-    pci_init();
-
-    quirks_init();
 
     acpi_init();
 

--- a/system/hwquirks.h
+++ b/system/hwquirks.h
@@ -12,14 +12,17 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#define QUIRK_TYPE_NONE     (1 << 0)
-#define QUIRK_TYPE_USB      (1 << 1)
-#define QUIRK_TYPE_SMP      (1 << 2)
-#define QUIRK_TYPE_SMBIOS   (1 << 3)
-#define QUIRK_TYPE_SMBUS    (1 << 4)
-#define QUIRK_TYPE_TIMER    (1 << 5)
-#define QUIRK_TYPE_MEM_SIZE (1 << 6)
-#define QUIRK_TYPE_TEMP     (1 << 7)
+#define QUIRK_TYPE_NONE       (1 <<  0)
+#define QUIRK_TYPE_USB        (1 <<  1)
+#define QUIRK_TYPE_SMP        (1 <<  2)
+#define QUIRK_TYPE_SMBIOS     (1 <<  3)
+#define QUIRK_TYPE_SMBUS      (1 <<  4)
+#define QUIRK_TYPE_TIMER      (1 <<  5)
+#define QUIRK_TYPE_MEM_SIZE   (1 <<  6)
+#define QUIRK_TYPE_TEMP       (1 <<  7)
+#define QUIRK_TYPE_ROTATE_90  (1 <<  8)
+#define QUIRK_TYPE_ROTATE_180 (1 <<  9)
+#define QUIRK_TYPE_ROTATE_270 (1 << 10)
 
 typedef enum {
     QUIRK_NONE,
@@ -37,7 +40,7 @@ typedef enum {
 
 typedef struct {
     quirk_id_t   id;
-    uint8_t      type;
+    uint16_t     type;
     uint16_t     root_vid;
     uint16_t     root_did;
     void (*process)(void);


### PR DESCRIPTION
This fixes #553 and introduces a new bug where the display area isn't correctly centered anymore. At the time of writing I have no idea why it does either of both.

Here a picture of a Steam Deck with the quirk (QUIRK_TYPE_ROTATE_90) applied:
![2025-10-25-17-45-28-444](https://github.com/user-attachments/assets/7fb9a740-2a5a-48b4-98eb-9037ebb840df)