### PR TITLE
Avoid glitch in runtime hours display when time is reset

### DIFF
--- a/app/display.h
+++ b/app/display.h
@@ -194,7 +194,7 @@ typedef enum {
     }
 
 #define display_run_time(hours, mins, secs) \
-    printf(7, 51, "%i:%02i:%02i", hours, mins, secs)
+    printf(7, 50, "%2i:%02i:%02i", hours, mins, secs)
 
 #define display_pass_count(count) \
     printi(8, 51, count, 0, false, true)


### PR DESCRIPTION
Use a space-padded width of two for displaying the hours.

Otherwise, if the hours had been 2 digit, the last digit from the seconds would linger after the hours were going 1 digit again.

Fixes #560