### PR TITLE
debug_memtest.sh: Extract offsets (also BSS) from code and binary

### DIFF
--- a/build/x86_64/debug_memtest.sh
+++ b/build/x86_64/debug_memtest.sh
@@ -125,6 +125,7 @@ Get_Offsets() {
     IMAGEBASE=$(grep -P '#define\tIMAGE_BASE' ../../boot/x86/header.S | cut -f4)
     BASEOFCODE=$(grep -P '#define\tBASE_OF_CODE' ../../boot/x86/header.S | cut -f3)
     DATA=0x$(objdump -t memtest.debug | grep -w _data | cut -d" " -f1)
+    BSS=0x$(objdump -t memtest.debug | grep -w _bss | cut -d" " -f1)
 
     # TODO: get BASEOFCODE and RELOCADDR (LOW_LOAD_LIMIT in app/main.c)
 }
@@ -144,6 +145,7 @@ Init_Gdb() {
 
     printf -v OFFSET "0x%X" $(($IMAGEBASE + $BASEOFCODE))
     printf -v DATAOFFSET "0x%X" $(($IMAGEBASE + $BASEOFCODE + $DATA))
+    printf -v BSSOFFSET "0x%X" $(($IMAGEBASE + $BASEOFCODE + $BSS))
     printf -v RELOCDATA "0x%X" $(($RELOCADDR + $DATA))
 
     GDB_FILE="gdbscript"
@@ -160,8 +162,8 @@ Init_Gdb() {
             exit 1
         fi
 
-        echo "add-symbol-file memtest.debug $OFFSET -s .data $DATAOFFSET" >> $GDB_FILE
-        echo "add-symbol-file memtest.debug $RELOCADDR -s .data $RELOCDATA" >> $GDB_FILE
+        echo "add-symbol-file memtest.debug $OFFSET -s .data $DATAOFFSET -s .bss $BSSOFFSET" >> $GDB_FILE
+        echo "add-symbol-file memtest.debug $RELOCADDR -s .data $RELOCDATA -s .bss $BSSOFFSET" >> $GDB_FILE
 
         echo "b main" >> $GDB_FILE
         echo "commands" >> $GDB_FILE


### PR DESCRIPTION
The hard-coded values were not correct any longer.

The correct BSS offset can be verified by e.g. "print cpu_model".