### PR TITLE
system/loongarch: Fixes display issues for 2K3000/3B6000M

### DIFF
--- a/system/loongarch/vmem.c
+++ b/system/loongarch/vmem.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <larchintrin.h>
+#include <string.h>
 
 #include "boot.h"
 
@@ -23,14 +24,31 @@ extern uint8_t highest_map_bit;
 #define DMW0_BASE         0x8000000000000000
 #define MMIO_BASE         DMW0_BASE | PCI_IO_PERFIX
 
+#define PCIE32_LOW_ADDRESS   0x30000000
+#define PCIE32_HIGH_ADDRESS  0x80000000
+#define PCIE40_LOW_ADDRESS   0x4000000000ULL
+#define PCIE40_HIGH_ADDRESS  0xC000000000ULL
+#define PCIE64_LOW_ADDRESS   0x8000000000ULL
+#define PCIE64_HIGH_ADDRESS  0xFD00000000ULL
 //------------------------------------------------------------------------------
 // Public Functions
 //------------------------------------------------------------------------------
 
 uintptr_t map_region(uintptr_t base_addr, size_t size __attribute__((unused)), bool only_for_startup __attribute__((unused)))
 {
-    if (((base_addr < 0x80000000) && (base_addr >= 0x30000000)) ||         // 32-bit PCI memory space
-      ((base_addr < 0xFD00000000ULL) && (base_addr >= 0x8000000000ULL)) || // 64-bit PCI memory space
+    const bool is_2k_or_3b6000m =
+        (strstr(cpuid_info.brand_id.str, "2K") != NULL) ||
+        (strstr(cpuid_info.brand_id.str, "3B6000M") != NULL);
+
+    // 32-bit PCI memory space base differs by platform
+    const uintptr_t pci32_lo = PCIE32_LOW_ADDRESS;
+    const uintptr_t pci32_hi = PCIE32_HIGH_ADDRESS;
+    // 64-bit PCI memory space base differs by platform
+    const uintptr_t pci64_lo = is_2k_or_3b6000m ? PCIE40_LOW_ADDRESS : PCIE64_LOW_ADDRESS;
+    const uintptr_t pci64_hi = is_2k_or_3b6000m ? PCIE40_HIGH_ADDRESS : PCIE64_HIGH_ADDRESS;
+
+    if (((base_addr < pci32_hi) && (base_addr >= pci32_lo)) ||  // 32-bit PCI memory space
+      ((base_addr < pci64_hi) && (base_addr >= pci64_lo)) ||    // 64-bit PCI memory space
       ((base_addr & PCI_IO_PERFIX) != 0x0)) {
         return MMIO_BASE | base_addr;
     } else if ((base_addr < 0x20000000) && (base_addr > 0x10000000)) {


### PR DESCRIPTION
On LoongArch, PCIe MMIO space above 4 GiB must be mapped as uncached;
otherwise writes may not reach the device, so framebuffer updates are not visible.
Adjust the PCIe memory window layout according to the Loongson 2K series documentation.
