### PR TITLE
Fix Secureboot to allow shim loading

### DIFF
--- a/boot/sbat.csv
+++ b/boot/sbat.csv
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-memtest86+,1,Memtest86+,6.0,https://github.com/memtest86plus
+memtest86+,1,Memtest86+,mt86plus,8.0,https://github.com/memtest86plus

--- a/boot/x86/startup64.S
+++ b/boot/x86/startup64.S
@@ -132,7 +132,21 @@ startup64:
 	.globl	efi_handover
 efi_handover:
 	andq	$~0xf, %rsp
-	call	efi_setup
+#	movq	%rdi, %r8		# save EFI image handle
+
+	# Clear .bss tail when VirtualSize > RawSize.
+#	xorq	%rax, %rax
+#	leaq	_bss(%rip), %rdi
+#	leaq	_end(%rip), %rcx
+#	subq	%rdi, %rcx
+#0:	cmpq	$0, %rcx
+#	je	1f
+#	movq	%rax, (%rdi)
+#	addq	$8, %rdi
+#	subq	$8, %rcx
+#	jmp	0b
+#1:	movq	%r8, %rdi		# restore EFI image handle
+    call	efi_setup
 
 	# Disable write protection in case the boot loader has made the
 	# loaded image read-only.

--- a/build/x86_64/ldscripts/memtest_efi.lds
+++ b/build/x86_64/ldscripts/memtest_efi.lds
@@ -50,13 +50,13 @@ SECTIONS {
 	_virt_head_size  = ((_file_head_size  + 4095) >> 12) << 12;
 	_virt_text_size  = ((_init_size       + 4095) >> 12) << 12;
 	_virt_reloc_size = ((_file_reloc_size + 4095) >> 12) << 12;
-	_virt_sbat_size  = ((_file_sbat_size  + 4095) >> 12) << 12;
+	_virt_sbat_size  = _real_sbat_size;
 
 	_virt_text_start  = _virt_head_size;
 	_virt_reloc_start = _virt_text_start  + _virt_text_size;
 	_virt_sbat_start  = _virt_reloc_start + _virt_reloc_size;
 
-	_virt_img_size = _virt_sbat_start + _virt_sbat_size;
+	_virt_img_size = ((_virt_sbat_start + _virt_sbat_size + 4095) >> 12) << 12;
 
 	. = ASSERT(header == 0x202, "The setup header has the wrong offset!");
 	. = ASSERT(_file_text_start == 0x1000, "The .text is at the wrong offset!");


### PR DESCRIPTION
This is a WIP to allow Memtest86+ to be loaded by shim, and ultimately allow running on Secure Boot enabled PC.

I fixed the sbat formatting and removed the alignment that prevented the section to be parsed correctly by shim. 

Now Shim correctly validate the file signature and is happy with the sbat format, but for some reasons, it can't load the image correctly. Just after shim ends its verification code and try to load the image, my test computer just ... shut down. This is highly unexpected. A freeze, error or crash would be more common, but it just shut down. The signed binary correctly runs on SB enabled PC when loaded directly without shim.

<img width="935" height="477" alt="image" src="https://github.com/user-attachments/assets/92e12bcd-c86e-41e9-be85-c6d67fee2968" />

I've tried a lot of stuff, but I can't understand what's the issue. I use Shim 15.8 source from Debian, so something could be wrong or hardcoded. The fact that it tries to load a "0xB8000" image seems wrong as it's much bigger than the size of Memtest86+ (but very close to the size of the original hardcoded grubx64.efi).

Any help welcome as I'm really not familiar with shim.
