### PR TITLE
Fix LA64-only linker RWX warnings

### DIFF
--- a/build/loongarch64/Makefile
+++ b/build/loongarch64/Makefile
@@ -192,9 +192,7 @@ mt86plus: memtest_shared.bin boot/loongarch/header.o ldscripts/memtest_efi.lds
 	$(eval SPLIT=$(shell nm -t d memtest_shared | awk '/ _etext_ro$$/{print $$1+0}'))
 	dd if=memtest_shared.bin of=memtest_text.bin bs=$(SPLIT) count=1 2>/dev/null
 	dd if=memtest_shared.bin of=memtest_data.bin bs=$(SPLIT) skip=1 2>/dev/null
-	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_text.bin memtest_data.bin -o memtest.elf
-	$(OBJCOPY) -O binary memtest.elf mt86plus
-	rm -f memtest.elf
+	$(LD) --defsym=_bss_size=$(word 3,$(SIZES)) -T ldscripts/memtest_efi.lds boot/loongarch/header.o -b binary memtest_text.bin memtest_data.bin -o mt86plus
 
 esp.img: mt86plus
 	@mkdir -p iso/EFI/BOOT

--- a/build/loongarch64/ldscripts/memtest_efi.lds
+++ b/build/loongarch64/ldscripts/memtest_efi.lds
@@ -1,4 +1,4 @@
-OUTPUT_FORMAT("elf64-loongarch")
+OUTPUT_FORMAT("binary")
 OUTPUT_ARCH(loongarch)
 
 ENTRY(head);

--- a/build/loongarch64/ldscripts/memtest_shared.lds
+++ b/build/loongarch64/ldscripts/memtest_shared.lds
@@ -2,6 +2,17 @@ OUTPUT_FORMAT("elf64-loongarch")
 OUTPUT_ARCH(loongarch);
 
 ENTRY(startup64);
+
+/* Explicit PHDRS so ld doesn't auto-merge the read-execute and read-write
+   sections into a single RWX LOAD segment (LoongArch ld will warn otherwise).
+   The output ELF is later objcopy'd to a flat binary, so these segments are
+   purely cosmetic, but the warning is silenced and the layout is explicit. */
+PHDRS {
+	text    PT_LOAD    FLAGS(5);  /* R_E */
+	data    PT_LOAD    FLAGS(6);  /* RW_ */
+	dynamic PT_DYNAMIC FLAGS(6);
+}
+
 SECTIONS {
 	. = 0;
 	.text : {
@@ -10,22 +21,22 @@ SECTIONS {
 		*(.text.*)
 		*(.plt)
 		_etext = . ;
-	} = 0x00004003
+	} = 0x00004003 :text
 	.rodata : {
 		*(.rodata)
 		*(.rodata.*)
-	}
-	.dynsym     : { *(.dynsym) }
-	.dynstr     : { *(.dynstr) }
-	.hash       : { *(.hash) }
-	.gnu.hash   : { *(.gnu.hash) }
+	} :text
+	.dynsym     : { *(.dynsym)   } :text
+	.dynstr     : { *(.dynstr)   } :text
+	.hash       : { *(.hash)     } :text
+	.gnu.hash   : { *(.gnu.hash) } :text
 	.shstrtab   : { *(.shstrtab) }
 
-	.rela.text    : { *(.rela.text   .rela.text.*) }
-	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) }
-	.rela.data    : { *(.rela.data   .rela.data.*) }
-	.rela.got     : { *(.rela.got    .rela.got.*) }
-	.rela.plt     : { *(.rela.plt    .rela.plt.*) }
+	.rela.text    : { *(.rela.text   .rela.text.*)   } :text
+	.rela.rodata  : { *(.rela.rodata .rela.rodata.*) } :text
+	.rela.data    : { *(.rela.data   .rela.data.*)   } :text
+	.rela.got     : { *(.rela.got    .rela.got.*)    } :text
+	.rela.plt     : { *(.rela.plt    .rela.plt.*)    } :text
 
 	/* Page-align the boundary between read-only and writable sections.
 	   PE SectionAlignment is 4096, so this ensures the split point
@@ -37,12 +48,12 @@ SECTIONS {
 		 _data = .;
 		*(.data)
 		*(.data.*)
-	}
+	} :data
 	.got : {
 		*(.got.plt)
 		*(.got)
-	}
-	.dynamic    : { *(.dynamic) }
+	} :data
+	.dynamic    : { *(.dynamic) } :data :dynamic
 	_edata = . ;
 	. = ALIGN(4);
 	.bss : {
@@ -57,6 +68,6 @@ SECTIONS {
 		/* _end must be at least 256 byte aligned */
 		. = ALIGN(256);
 		_end = .;
-	}
+	} :data
 	/DISCARD/ : { *(*) }
 }

--- a/build/loongarch64/ldscripts/memtest_shared.lds
+++ b/build/loongarch64/ldscripts/memtest_shared.lds
@@ -21,7 +21,7 @@ SECTIONS {
 		*(.text.*)
 		*(.plt)
 		_etext = . ;
-	} = 0x00004003 :text
+	} :text = 0x00004003
 	.rodata : {
 		*(.rodata)
 		*(.rodata.*)


### PR DESCRIPTION
Minor changes. No impact on i586/x86_64.