### PR TITLE
Fix double handling of key input

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -498,6 +498,7 @@ void check_input(void)
     } else if (big_status_displayed) {
         restore_big_status();
         enable_big_status = false;
+        return;
     }
 
     switch (input_key) {


### PR DESCRIPTION
When PASS / FAIL is displayed, the key press for closing that window ("Press any key to remove this banner") is not properly handled. If the chosen any key is one of the "hotkeys" not only does one key press closes that window, but also executes the action behind the hotkey.

### Steps to reproduce:
1. Wait for PASS / FAIL window
2. Press ESC as the any key
3. Window closes
4. System reboots

IMHO the expected behaviour should be that the chosen key only closes the PASS / FAIL window and nothing else.