### PR TITLE
Display memory info from DMI when SPD is unavailable

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -303,7 +303,11 @@ void display_cpu_topology(void)
 void post_display_init(void)
 {
     print_smbios_startup_info();
-    print_spd_startup_info();
+
+    if (print_spd_startup_info() == 0) {
+        // No SPD data, fall back to SMBIOS Type 17 info.
+        print_dmi_memory_info();
+    }
 
     if (imc.freq) {
         // Try to get RAM information from IMC

--- a/system/i2c_x86.h
+++ b/system/i2c_x86.h
@@ -108,10 +108,10 @@ struct pci_smbus_controller {
 };
 
 /**
- * Print SPD Info
+ * Print SPD Info. Return the number of modules found.
  */
 
-void print_spd_startup_info(void);
+int print_spd_startup_info(void);
 
 uint8_t get_spd(uint8_t slot_idx, uint16_t spd_adr);
 uint8_t get_spd_hub_register(uint8_t slot_idx, uint8_t spd_hub_adr);

--- a/system/loongarch/i2c.c
+++ b/system/loongarch/i2c.c
@@ -192,7 +192,7 @@ uint8_t get_spd(uint8_t slot_idx, uint16_t spd_adr)
     return i2c_read_byte(i2c_info.i2c_mc[mc].i2c_base, device_id, spd_adr);
 }
 
-void print_spd_startup_info(void)
+int print_spd_startup_info(void)
 {
     uint8_t spdidx = 0, spd_line_idx = 0;
 
@@ -201,7 +201,7 @@ void print_spd_startup_info(void)
     curspd.isValid = false;
 
     if (!determine_i2c_address()) {
-        return;
+        return 0;
     }
 
     for (spdidx = 0; spdidx < max_mc_nu * 2; spdidx++) {
@@ -218,4 +218,6 @@ void print_spd_startup_info(void)
         print_spdi(curspd, ROW_SPD+spd_line_idx);
         spd_line_idx++;
     }
+
+    return spd_line_idx;
 }

--- a/system/smbios.c
+++ b/system/smbios.c
@@ -4,6 +4,7 @@
 
 #include "stdint.h"
 #include "string.h"
+#include "ctype.h"
 #include "display.h"
 
 #include "boot.h"
@@ -11,6 +12,7 @@
 #include "cpuinfo.h"
 #include "efi.h"
 #include "vmem.h"
+#include "spd.h"
 #include "smbios.h"
 
 #define LINE_DMI 23
@@ -23,10 +25,17 @@ static const efi_guid_t SMBIOS2_GUID = { 0xeb9d2d31, 0x2d88, 0x11d3, {0x9a, 0x16
 // Some firmware (e.g. QEMU virt, ARM laptops) only publishes the 64-bit SMBIOS v3 entry point.
 static const efi_guid_t SMBIOS3_GUID = { 0xf2fd1544, 0x9794, 0x4a2c, {0x99, 0x2e, 0xe5, 0xbb, 0xcf, 0x20, 0xe3, 0x94} };
 
+// Consumers of dmi_memory_device read ->type without a NULL check, so point
+// it at an all-zero struct (type 0 = undefined) until a real one is found.
+static struct mem_dev null_mem_dev;
+
 struct system_info *dmi_system_info;
 struct baseboard_info *dmi_baseboard_info;
-struct mem_dev *dmi_memory_device;
+struct mem_dev *dmi_memory_device = &null_mem_dev;
 struct cpu_info *dmi_cpu_info;
+
+struct mem_dev *dmi_memory_devices[MAX_DMI_MEM_DEVICES];
+int dmi_num_memory_devices = 0;
 
 static char *get_tstruct_string(struct tstruct_header *header, uint16_t maxlen, int n)
 {
@@ -158,11 +167,17 @@ static int parse_dmi(uint16_t numstructs)
         }
         // Type 17 - Memory Device
         else if (header->type == 17 && header->length > offsetof(struct mem_dev, partnum)) {
+            struct mem_dev *mdev = (struct mem_dev *) dmi;
             // Multiple type 17 structs are allowed, with unpopulated slots sometimes
             // reported as type 2 (unknown). If type is 0 (uninitialized) or 1/2 (previously
             // initialized with unknown value) => set or overwrite the struct
-            if (dmi_memory_device == NULL || dmi_memory_device->type <= 2) {
-                dmi_memory_device = (struct mem_dev *) dmi;
+            if (dmi_memory_device->type <= 2) {
+                dmi_memory_device = mdev;
+            }
+            // Collect every populated device (size 0 means empty socket,
+            // 0xFFFF means populated with unknown size, so keep the latter).
+            if (mdev->size != 0 && dmi_num_memory_devices < MAX_DMI_MEM_DEVICES) {
+                dmi_memory_devices[dmi_num_memory_devices++] = mdev;
             }
         }
 
@@ -172,6 +187,7 @@ static int parse_dmi(uint16_t numstructs)
             dmi_system_info = NULL;
             dmi_baseboard_info = NULL;
             dmi_cpu_info = NULL;
+            dmi_num_memory_devices = 0;
             return -1;
         }
 
@@ -185,6 +201,7 @@ static int parse_dmi(uint16_t numstructs)
             dmi_system_info = NULL;
             dmi_baseboard_info = NULL;
             dmi_cpu_info = NULL;
+            dmi_num_memory_devices = 0;
             return -1;
         }
     }
@@ -365,5 +382,298 @@ void print_smbios_startup_info(void)
                 }
             }
         }
+    }
+}
+
+// ---------------------------------------------------
+// DMI Type 17 fallback display (used when SPD fails)
+// ---------------------------------------------------
+
+#define DMI_MANUF_LEN   20
+#define DMI_PART_LEN    26
+
+// Type 17 structs are variable-length: fields beyond SMBIOS 2.3 are only
+// present when the struct is long enough to contain them.
+#define MEMDEV_HAS_FIELD(md, field) \
+    ((md)->header.length >= offsetof(struct mem_dev, field) + sizeof((md)->field))
+
+typedef struct {
+    uint64_t    size_kb;                        // 0 = unknown
+    uint32_t    speed;                          // MT/s, 0 = unknown
+    uint8_t     type;                           // raw DMI memory type byte
+    const char *manuf;                          // JEP-106 name, manuf_str or NULL
+    char        manuf_str[DMI_MANUF_LEN + 1];
+    char        part_num[DMI_PART_LEN + 1];
+    int         count;
+} dmi_mem_group_t;
+
+static uint64_t memdev_size_kb(const struct mem_dev *md)
+{
+    if (md->size == 0 || md->size == 0xFFFF) {
+        return 0;                               // empty socket / unknown size
+    }
+    if (md->size == 0x7FFF) {
+        // Real size is in ext_size (SMBIOS 2.7+), in MB, bits 30:0.
+        if (!MEMDEV_HAS_FIELD(md, ext_size)) {
+            return 0;
+        }
+        return (uint64_t)(md->ext_size & 0x7FFFFFFF) * 1024;
+    }
+    if (md->size & 0x8000) {
+        return md->size & 0x7FFF;               // value is in KB
+    }
+    return (uint64_t)md->size * 1024;           // value is in MB
+}
+
+static uint32_t memdev_speed_mts(const struct mem_dev *md)
+{
+    // Prefer the configured (actual) speed (SMBIOS 2.7+).
+    if (MEMDEV_HAS_FIELD(md, conf_ram_speed)) {
+        uint16_t conf = md->conf_ram_speed;
+        if (conf == 0xFFFF) {
+            if (MEMDEV_HAS_FIELD(md, extended_conf_speed) && md->extended_conf_speed != 0) {
+                return md->extended_conf_speed;
+            }
+        } else if (conf != 0) {
+            return conf;
+        }
+    }
+    // Fall back to the maximum rated speed.
+    if (md->speed == 0xFFFF) {
+        if (MEMDEV_HAS_FIELD(md, extended_speed)) {
+            return md->extended_speed;
+        }
+        return 0;
+    }
+    return md->speed;
+}
+
+static const char *memdev_type_str(uint8_t type)
+{
+    switch (type) {
+      case DMI_SDR:
+        return "SDRAM";
+      case DMI_RDRAM:
+        return "RDRAM";
+      case DMI_DDR:
+        return "DDR";
+      case DMI_DDR2:
+      case DMI_DDR2_FBDIMM:
+        return "DDR2";
+      case DMI_DDR3:
+        return "DDR3";
+      case DMI_DDR4:
+        return "DDR4";
+      case DMI_LPDDR:
+        return "LPDDR";
+      case DMI_LPDDR2:
+        return "LPDDR2";
+      case DMI_LPDDR3:
+        return "LPDDR3";
+      case DMI_LPDDR4:
+        return "LPDDR4";
+      case DMI_DDR5:
+        return "DDR5";
+      case DMI_LPDDR5:
+        return "LPDDR5";
+      default:
+        return NULL;                            // "Unknown", "Other", "RAM", ...
+    }
+}
+
+static const char *memdev_jep106_name(const struct mem_dev *md)
+{
+    if (!MEMDEV_HAS_FIELD(md, module_manufacturer_id)) {
+        return NULL;
+    }
+    // SMBIOS 3.2+: the two SPD manufacturer bytes, LSB first. The low byte
+    // of the (little-endian) word is the continuation-code count, the high
+    // byte the manufacturer code, each with an odd-parity bit 7.
+    uint16_t id = md->module_manufacturer_id;
+    if (id == 0 || id == 0xFFFF) {
+        return NULL;
+    }
+    uint8_t cont = id & 0x7F;
+    uint8_t code = (id >> 8) & 0x7F;
+    if (code == 0 || code == 0x7F) {
+        return NULL;
+    }
+    return get_jep106_name(((uint16_t)(cont & 0x1F) << 8) | code);
+}
+
+static bool dmi_string_is_junk(const char *s, size_t len)
+{
+    static const char *const junk[] = {
+        "Unknown", "Not Specified", "Not Available", "To Be Filled By O.E.M.",
+        "NO DIMM", "No Module Installed", "None", "N/A", "Undefined",
+        "Default string", "Part Num", "PartNum", "Manufacturer", "Module Manufacturer"
+    };
+
+    if (len == 0) {
+        return true;
+    }
+    for (size_t i = 0; i < sizeof(junk) / sizeof(junk[0]); i++) {
+        const char *b = junk[i];
+        size_t k = 0;
+        while (k < len && b[k] != '\0'
+               && toupper((unsigned char)s[k]) == toupper((unsigned char)b[k])) {
+            k++;
+        }
+        if (k == len && b[k] == '\0') {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool copy_dmi_string(char *dst, size_t dst_size, struct mem_dev *md, uint8_t string_idx)
+{
+    dst[0] = '\0';
+
+    uint32_t remaining = table_length - (uint32_t)((const uint8_t *)md - table_start);
+    uint16_t maxlen = remaining > UINT16_MAX ? UINT16_MAX : remaining;
+
+    const char *src = get_tstruct_string(&md->header, maxlen, string_idx);
+    if (src == NULL) {
+        return false;
+    }
+    while (*src == ' ') {                       // skip leading spaces
+        src++;
+    }
+    size_t src_len = strlen(src);
+    while (src_len > 0 && src[src_len - 1] == ' ') {  // ignore trailing spaces
+        src_len--;
+    }
+
+    // Filter placeholders on the full string, before any truncation.
+    if (dmi_string_is_junk(src, src_len)) {
+        return false;
+    }
+
+    size_t len = src_len < dst_size - 1 ? src_len : dst_size - 1;
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+    return true;
+}
+
+static bool dmi_manuf_match(const char *a, const char *b)
+{
+    if (a == NULL || b == NULL) {
+        return a == b;
+    }
+    return strncmp(a, b, DMI_MANUF_LEN + 1) == 0;
+}
+
+static void print_dmi_mem_group(const dmi_mem_group_t *group, int row)
+{
+    int col = prints(row, 0, " -");
+
+    if (group->count > 1) {
+        col = printf(row, col + 1, "%ix", group->count);
+    }
+    if (group->size_kb != 0) {
+        col = printf(row, col + 1, "%kB", (uintptr_t)group->size_kb);
+    }
+
+    const char *tstr = memdev_type_str(group->type);
+    if (tstr != NULL && group->speed != 0) {
+        col = printf(row, col + 1, "%s-%i", tstr, group->speed);
+    } else if (tstr != NULL) {
+        col = prints(row, col + 1, tstr);
+    } else if (group->speed != 0) {
+        col = printf(row, col + 1, "%i MT/s", group->speed);
+    }
+
+    if (group->manuf != NULL) {
+        col = printf(row, col + 1, "- %s", group->manuf);
+    }
+    if (group->part_num[0] != '\0' && col + 1 + (int)strlen(group->part_num) < SCREEN_WIDTH) {
+        prints(row, col + 1, group->part_num);
+    }
+}
+
+void print_dmi_memory_info(void)
+{
+    // Static: called once at startup, single-threaded; keeps ~2 kB off the stack.
+    static dmi_mem_group_t groups[MAX_DMI_MEM_DEVICES];
+    int num_groups = 0;
+
+    for (int i = 0; i < dmi_num_memory_devices; i++) {
+        struct mem_dev *md = dmi_memory_devices[i];
+        dmi_mem_group_t g;
+
+        memset(&g, 0, sizeof(g));
+        g.size_kb = memdev_size_kb(md);
+        g.speed   = memdev_speed_mts(md);
+        g.type    = md->type;
+        g.manuf   = memdev_jep106_name(md);
+        if (g.manuf == NULL && copy_dmi_string(g.manuf_str, sizeof(g.manuf_str), md, md->manufacturer)) {
+            g.manuf = g.manuf_str;
+        }
+        if (!copy_dmi_string(g.part_num, sizeof(g.part_num), md, md->partnum)) {
+            g.part_num[0] = '\0';
+        }
+
+        // Skip devices carrying no usable info at all.
+        if (g.size_kb == 0 && g.speed == 0 && memdev_type_str(g.type) == NULL
+            && g.manuf == NULL && g.part_num[0] == '\0') {
+            continue;
+        }
+
+        // Collapse identical modules into a single group.
+        int j;
+        for (j = 0; j < num_groups; j++) {
+            if (groups[j].size_kb == g.size_kb && groups[j].speed == g.speed
+                && groups[j].type == g.type && dmi_manuf_match(groups[j].manuf, g.manuf)
+                && strncmp(groups[j].part_num, g.part_num, DMI_PART_LEN + 1) == 0) {
+                groups[j].count++;
+                break;
+            }
+        }
+        if (j == num_groups) {
+            g.count = 1;
+            groups[num_groups] = g;
+            if (g.manuf == g.manuf_str) {
+                groups[num_groups].manuf = groups[num_groups].manuf_str;
+            }
+            num_groups++;
+        }
+    }
+
+    if (num_groups == 0) {
+        return;
+    }
+
+    // Header, with the common type and max speed when all groups agree.
+    const char *tstr = memdev_type_str(groups[0].type);
+    uint32_t max_speed = 0;
+    bool same_type = true;
+    for (int i = 0; i < num_groups; i++) {
+        if (groups[i].type != groups[0].type) {
+            same_type = false;
+        }
+        if (groups[i].speed > max_speed) {
+            max_speed = groups[i].speed;
+        }
+    }
+
+    int hdr_len;
+    if (same_type && tstr != NULL && max_speed != 0) {
+        hdr_len = printf(ROW_SPD - 2, 0, "Memory DMI Information (%s-%i)", tstr, max_speed);
+    } else {
+        hdr_len = prints(ROW_SPD - 2, 0, "Memory DMI Information");
+    }
+
+    char dashes[SCREEN_WIDTH];
+    if (hdr_len >= SCREEN_WIDTH) {
+        hdr_len = SCREEN_WIDTH - 1;
+    }
+    memset(dashes, '-', hdr_len);
+    dashes[hdr_len] = '\0';
+    prints(ROW_SPD - 1, 0, dashes);
+
+    // Same row budget as the SPD display.
+    for (int i = 0; i < num_groups && i < MAX_SPD_SLOT; i++) {
+        print_dmi_mem_group(&groups[i], ROW_SPD + i);
     }
 }

--- a/system/smbios.c
+++ b/system/smbios.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (C) 2022 Samuel Demeulemeester
+// Copyright (C) 2022-2026 Samuel Demeulemeester
 //
 
 #include "stdint.h"
@@ -8,6 +8,7 @@
 
 #include "boot.h"
 #include "bootparams.h"
+#include "cpuinfo.h"
 #include "efi.h"
 #include "vmem.h"
 #include "smbios.h"
@@ -19,12 +20,13 @@ static uint32_t table_length = 0; // 16-bit in SMBIOS v2, 32-bit in SMBIOS v3.
 
 static const efi_guid_t SMBIOS2_GUID = { 0xeb9d2d31, 0x2d88, 0x11d3, {0x9a, 0x16, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d} };
 
-// SMBIOS v3 compliant FW must include an SMBIOS v2 table, but maybe parse SM3 table later...
-// static const efi_guid_t SMBIOS3_GUID = { 0xf2fd1544, 0x9794, 0x4a2c, {0x99, 0x2e, 0xe5, 0xbb, 0xcf, 0x20, 0xe3, 0x94} };
+// Some firmware (e.g. QEMU virt, ARM laptops) only publishes the 64-bit SMBIOS v3 entry point.
+static const efi_guid_t SMBIOS3_GUID = { 0xf2fd1544, 0x9794, 0x4a2c, {0x99, 0x2e, 0xe5, 0xbb, 0xcf, 0x20, 0xe3, 0x94} };
 
 struct system_info *dmi_system_info;
 struct baseboard_info *dmi_baseboard_info;
 struct mem_dev *dmi_memory_device;
+struct cpu_info *dmi_cpu_info;
 
 static char *get_tstruct_string(struct tstruct_header *header, uint16_t maxlen, int n)
 {
@@ -43,68 +45,66 @@ static char *get_tstruct_string(struct tstruct_header *header, uint16_t maxlen, 
 }
 
 #if (ARCH_BITS == 64)
-static smbiosv2_t *find_smbiosv2_in_efi64_system_table(efi64_system_table_t *system_table)
+static uintptr_t find_in_efi64_system_table(efi64_system_table_t *system_table, const efi_guid_t *guid)
 {
     efi64_config_table_t *config_tables = (efi64_config_table_t *) map_region(system_table->config_tables, system_table->num_config_tables * sizeof(efi64_config_table_t), true);
-    if (config_tables == NULL) return NULL;
+    if (config_tables == NULL) return 0;
 
     uintptr_t table_addr = 0;
     for (uint32_t i = 0; i < system_table->num_config_tables; i++) {
-        if (memcmp( & config_tables[i].guid, & SMBIOS2_GUID, sizeof(efi_guid_t)) == 0) {
+        if (memcmp( & config_tables[i].guid, guid, sizeof(efi_guid_t)) == 0) {
             table_addr = config_tables[i].table;
         }
     }
-    return (smbiosv2_t *) table_addr;
+    return table_addr;
 }
 #endif
 
-static smbiosv2_t *find_smbiosv2_in_efi32_system_table(efi32_system_table_t *system_table)
+static uintptr_t find_in_efi32_system_table(efi32_system_table_t *system_table, const efi_guid_t *guid)
 {
     efi32_config_table_t *config_tables = (efi32_config_table_t *) map_region(system_table->config_tables, system_table->num_config_tables * sizeof(efi32_config_table_t), true);
-    if (config_tables == NULL) return NULL;
+    if (config_tables == NULL) return 0;
 
     uintptr_t table_addr = 0;
     for (uint32_t i = 0; i < system_table->num_config_tables; i++) {
-        if (memcmp( & config_tables[i].guid, & SMBIOS2_GUID, sizeof(efi_guid_t)) == 0) {
+        if (memcmp( & config_tables[i].guid, guid, sizeof(efi_guid_t)) == 0) {
             table_addr = config_tables[i].table;
         }
     }
-    return (smbiosv2_t *) table_addr;
+    return table_addr;
 }
 
-static uintptr_t find_smbiosv2_adr(void)
+static uintptr_t find_efi_config_table(const efi_guid_t *guid)
 {
     const boot_params_t *boot_params = (boot_params_t *) boot_params_addr;
     const efi_info_t *efi_info = & boot_params->efi_info;
 
-    smbiosv2_t *rp = NULL;
-
     if (efi_info->loader_signature == EFI32_LOADER_SIGNATURE) {
-        // EFI32
-        if (rp == NULL && efi_info->loader_signature == EFI32_LOADER_SIGNATURE) {
-            uintptr_t system_table_addr = map_region(efi_info->sys_tab, sizeof(efi32_system_table_t), true);
-            system_table_addr = map_region(system_table_addr, sizeof(efi32_system_table_t), true);
-            if (system_table_addr != 0) {
-                rp = find_smbiosv2_in_efi32_system_table((efi32_system_table_t *) system_table_addr);
-                return (uintptr_t) rp;
-            }
+        uintptr_t system_table_addr = map_region(efi_info->sys_tab, sizeof(efi32_system_table_t), true);
+        if (system_table_addr != 0) {
+            return find_in_efi32_system_table((efi32_system_table_t *) system_table_addr, guid);
         }
     }
 #if (ARCH_BITS == 64)
-    if (rp == NULL && efi_info -> loader_signature == EFI64_LOADER_SIGNATURE) {
-        // EFI64
-        if (rp == NULL && efi_info->loader_signature == EFI64_LOADER_SIGNATURE) {
-            uintptr_t system_table_addr = (uintptr_t) efi_info->sys_tab_hi << 32 | (uintptr_t) efi_info->sys_tab;
-            system_table_addr = map_region(system_table_addr, sizeof(efi64_system_table_t), true);
-            if (system_table_addr != 0) {
-                rp = find_smbiosv2_in_efi64_system_table((efi64_system_table_t *) system_table_addr);
-                return (uintptr_t) rp;
-            }
+    if (efi_info->loader_signature == EFI64_LOADER_SIGNATURE) {
+        uintptr_t system_table_addr = (uintptr_t) efi_info->sys_tab_hi << 32 | (uintptr_t) efi_info->sys_tab;
+        system_table_addr = map_region(system_table_addr, sizeof(efi64_system_table_t), true);
+        if (system_table_addr != 0) {
+            return find_in_efi64_system_table((efi64_system_table_t *) system_table_addr, guid);
         }
     }
 #endif
-    if (rp == NULL) {
-        // BIOS
+    return 0;
+}
+
+static uintptr_t find_smbiosv2_adr(void)
+{
+    uintptr_t rp = find_efi_config_table(&SMBIOS2_GUID);
+
+#if defined(__i386__) || defined(__x86_64__)
+    if (rp == 0) {
+        // BIOS. Only x86 has a legacy BIOS area; on other architectures
+        // this region may not even be mapped.
         uint8_t *dmi, *dmi_search_start;
         dmi_search_start = (uint8_t *) 0x000F0000;
 
@@ -113,8 +113,9 @@ static uintptr_t find_smbiosv2_adr(void)
                 return (uintptr_t) dmi;
         }
     }
+#endif
 
-    return 0;
+    return rp;
 }
 
 static int parse_dmi(uint16_t numstructs)
@@ -132,6 +133,12 @@ static int parse_dmi(uint16_t numstructs)
     while (dmi < table_start + table_length - 2) { // -2 for header type and length.
         const struct tstruct_header *header = (struct tstruct_header *) dmi;
 
+        // Type 127 - End-of-Table. Mandatory with the v3 entry point, whose
+        // table length is only an upper bound.
+        if (header->type == 127) {
+            break;
+        }
+
         // Type 1 - System Information
         if (header->type == 1 && header->length > offsetof(struct system_info, wut)) {
             // Multiple type 1 structs are not allowed by the standard. Still, effectively pick up the last one.
@@ -142,12 +149,19 @@ static int parse_dmi(uint16_t numstructs)
             // Multiple type 2 structs are allowed by the standard. Effectively pick up the last one.
             dmi_baseboard_info = (struct baseboard_info *) dmi;
         }
+        // Type 4 - Processor Information
+        else if (header->type == 4 && header->length > offsetof(struct cpu_info, version)) {
+            // One struct per socket; keep the first populated one.
+            if (dmi_cpu_info == NULL) {
+                dmi_cpu_info = (struct cpu_info *) dmi;
+            }
+        }
         // Type 17 - Memory Device
         else if (header->type == 17 && header->length > offsetof(struct mem_dev, partnum)) {
             // Multiple type 17 structs are allowed, with unpopulated slots sometimes
             // reported as type 2 (unknown). If type is 0 (uninitialized) or 1/2 (previously
             // initialized with unknown value) => set or overwrite the struct
-            if (dmi_memory_device->type <= 2) {
+            if (dmi_memory_device == NULL || dmi_memory_device->type <= 2) {
                 dmi_memory_device = (struct mem_dev *) dmi;
             }
         }
@@ -157,6 +171,7 @@ static int parse_dmi(uint16_t numstructs)
         if (dmi >= table_start + table_length) {
             dmi_system_info = NULL;
             dmi_baseboard_info = NULL;
+            dmi_cpu_info = NULL;
             return -1;
         }
 
@@ -169,49 +184,151 @@ static int parse_dmi(uint16_t numstructs)
         if ((dmi > table_start + table_length) || (++tstruct_count > numstructs)) {
             dmi_system_info = NULL;
             dmi_baseboard_info = NULL;
+            dmi_cpu_info = NULL;
             return -1;
         }
     }
     return 0;
 }
 
+#if defined(__aarch64__)
+// There is no architectural way to get the CPU marketing name on ARM, so
+// the MIDR-derived name only identifies the microarchitecture (e.g.
+// "Qualcomm Oryon"). Prefer the SMBIOS processor version string (e.g.
+// "Snapdragon(R) X Elite - X1E80100") when the firmware provides one.
+
+#define CPU_VERSION_MAX_LEN 50  // display width available for the CPU model
+
+static char cpu_version_str[CPU_VERSION_MAX_LEN + 1];
+
+static void override_cpu_model(void)
+{
+    if (dmi_cpu_info == NULL) {
+        return;
+    }
+
+    uint16_t struct_length = table_length - ((uint8_t *)&dmi_cpu_info->header - (uint8_t *)table_start);
+
+    const char *version = get_tstruct_string(&dmi_cpu_info->header, struct_length, dmi_cpu_info->version);
+    if (version == NULL) {
+        return;
+    }
+
+    size_t len = 0;
+    int has_content = 0;
+    while (version[len] != '\0' && len < CPU_VERSION_MAX_LEN) {
+        if (version[len] != ' ') {
+            has_content = 1;
+        }
+        cpu_version_str[len] = version[len];
+        len++;
+    }
+    if (version[len] != '\0') {
+        // Truncated: back up to the last word boundary.
+        while (len > 0 && cpu_version_str[len - 1] != ' ') {
+            len--;
+        }
+    }
+    // Trim trailing spaces and dangling separators.
+    while (len > 0 && (cpu_version_str[len - 1] == ' ' || cpu_version_str[len - 1] == '-')) {
+        len--;
+    }
+    cpu_version_str[len] = '\0';
+
+    if (has_content && len > 0) {
+        cpu_model = cpu_version_str;
+    }
+}
+#endif
+
+static int8_t table_checksum(const uint8_t *start, uint8_t length)
+{
+    int8_t checksum = 0;
+
+    for (const uint8_t *p = start; p < (start + length); p++) {
+        checksum += *p;
+    }
+    return checksum;
+}
+
 int smbios_init(void)
 {
     uintptr_t smb_adr;
-    const uint8_t *dmi_start;
-    const smbiosv2_t *eps;
 
-    // Get SMBIOS Address
+    uint64_t dmi_table_addr = 0;
+    uint32_t dmi_table_length = 0;
+    uint16_t numstructs = 0;
+
+    // Prefer the SMBIOS v2 (32-bit) entry point, which gives an exact struct
+    // count, but fall back to the v3 (64-bit) one: some firmware (e.g. QEMU
+    // virt, ARM laptops) only publishes the latter.
     smb_adr = find_smbiosv2_adr();
+    if (smb_adr != 0) {
+        // The entry point lives in firmware-reserved memory, which may not
+        // be mapped yet.
+        smb_adr = map_region(smb_adr, sizeof(smbiosv2_t), true);
+        if (smb_adr == 0) {
+            return -1;
+        }
+        const smbiosv2_t *eps = (const smbiosv2_t *) smb_adr;
 
-    if (smb_adr == 0) {
+        if (table_checksum((const uint8_t *) smb_adr, eps->length) != 0) {
+            return -1;
+        }
+
+        // SMBIOS 2.3 required
+        if (eps->majorversion < 2 && eps->minorversion < 3) {
+            return -1;
+        }
+
+        dmi_table_addr = eps->tableaddress;
+        dmi_table_length = eps->tablelength;
+        numstructs = eps->numstructs;
+    } else {
+        smb_adr = find_efi_config_table(&SMBIOS3_GUID);
+        if (smb_adr == 0) {
+            return -1;
+        }
+        smb_adr = map_region(smb_adr, sizeof(smbiosv3_t), true);
+        if (smb_adr == 0) {
+            return -1;
+        }
+        const smbiosv3_t *eps = (const smbiosv3_t *) smb_adr;
+
+        if (table_checksum((const uint8_t *) smb_adr, eps->length) != 0) {
+            return -1;
+        }
+
+        dmi_table_addr = eps->tableaddress;
+        dmi_table_length = eps->maxsize;
+        // The v3 entry point has no struct count; parsing stops at the
+        // mandatory end-of-table struct.
+        numstructs = UINT16_MAX;
+    }
+
+#if (ARCH_BITS == 32)
+    if (dmi_table_addr > UINT32_MAX) {
         return -1;
     }
+#endif
 
-    dmi_start = (const uint8_t *) smb_adr;
-    eps = (const smbiosv2_t *) smb_adr;
-
-    // Verify checksum
-    int8_t checksum = 0;
-    const uint8_t *dmi = dmi_start;
-
-    for (; dmi < (dmi_start + eps->length); dmi++) {
-        checksum += *dmi;
-    }
-
-    if (checksum) {
+    // The DMI structure table also lives in firmware-reserved memory.
+    uintptr_t table_addr = map_region((uintptr_t)dmi_table_addr, dmi_table_length, true);
+    if (table_addr == 0) {
         return -1;
     }
+    table_start = (const uint8_t *)table_addr;
+    table_length = dmi_table_length;
 
-    // SMBIOS 2.3 required
-    if (eps->majorversion < 2 && eps->minorversion < 3) {
-        return -1;
+    int result = parse_dmi(numstructs);
+
+#if defined(__aarch64__)
+    if (result == 0) {
+        override_cpu_model();
     }
+#endif
 
-    table_start = (const uint8_t *)(uintptr_t)eps->tableaddress;
-    table_length = (uint32_t)eps->tablelength;
-
-    return parse_dmi(eps->numstructs);
+    return result;
 }
 
 void print_smbios_startup_info(void)

--- a/system/smbios.h
+++ b/system/smbios.h
@@ -6,7 +6,7 @@
  *
  * Provides functions for reading SMBIOS tables
  *
- * Copyright (C) 2004-2022 Samuel Demeulemeester.
+ * Copyright (C) 2004-2026 Samuel Demeulemeester.
  */
 
 #define DMI_SDR         0x0F
@@ -40,6 +40,19 @@ typedef struct {
     uint8_t SMBIOSrev;
 } smbiosv2_t;
 
+typedef struct {
+    uint8_t anchor[5];  // "_SM3_"
+    int8_t checksum;
+    uint8_t length;
+    uint8_t majorversion;
+    uint8_t minorversion;
+    uint8_t docrev;
+    uint8_t revision;
+    uint8_t reserved;
+    uint32_t maxsize;
+    uint64_t tableaddress;
+} __attribute__((packed)) smbiosv3_t;
+
 struct tstruct_header {
     uint8_t type;
     uint8_t length;
@@ -70,6 +83,28 @@ struct baseboard_info {
     uint16_t chassis_handle;
     uint8_t  board_type;
     uint16_t number_contained_object_handles;*/
+} __attribute__((packed));
+
+struct cpu_info {
+    struct tstruct_header header;
+    uint8_t  socket_designation;
+    uint8_t  cpu_type;
+    uint8_t  family;
+    uint8_t  manufacturer;
+    uint8_t  cpuid[8];
+    uint8_t  version;
+    uint8_t  voltage;
+    uint16_t ext_clock;
+    uint16_t max_speed;
+    uint16_t cur_speed;
+    uint8_t  status;
+    uint8_t  upgrade; // Last field defined by SMBIOS 2.0.
+    /*uint16_t l1_handle;
+    uint16_t l2_handle;
+    uint16_t l3_handle;
+    uint8_t  serialnumber;
+    uint8_t  asset_tag;
+    uint8_t  partnumber;*/
 } __attribute__((packed));
 
 struct mem_module {
@@ -127,6 +162,12 @@ struct mem_dev {
  */
 
 extern struct mem_dev *dmi_memory_device;
+
+/**
+ * Processor Information Structure (SMBIOS type 4)
+ */
+
+extern struct cpu_info *dmi_cpu_info;
 
 /**
  * Initialize SMBIOS/DMI (locate struct)

--- a/system/smbios.h
+++ b/system/smbios.h
@@ -136,12 +136,12 @@ struct mem_dev {
     uint8_t  serialnum;
     uint8_t  asset;
     uint8_t  partnum; // Last field defined by SMBIOS 2.3.
-    /*uint8_t  attributes;
+    uint8_t  attributes; // Last field defined by SMBIOS 2.6.
     uint32_t ext_size;
-    uint16_t conf_ram_speed;
+    uint16_t conf_ram_speed; // Last field defined by SMBIOS 2.7.
     uint16_t min_voltage;
-    uint16_t max_votage;
-    uint16_t conf_voltage;
+    uint16_t max_voltage;
+    uint16_t conf_voltage; // Last field defined by SMBIOS 2.8.
     uint8_t  technology;
     uint16_t operating_mode_capability;
     uint8_t  firmware_version;
@@ -152,9 +152,9 @@ struct mem_dev {
     uint64_t nonvolatile_size;
     uint64_t volatile_size;
     uint64_t cache_size;
-    uint64_t logical_size;
+    uint64_t logical_size; // Last field defined by SMBIOS 3.2.
     uint32_t extended_speed;
-    uint32_t extended_conf_speed;*/
+    uint32_t extended_conf_speed; // Last field defined by SMBIOS 3.3.
 } __attribute__((packed));
 
 /**
@@ -162,6 +162,17 @@ struct mem_dev {
  */
 
 extern struct mem_dev *dmi_memory_device;
+
+/**
+ * Maximum number of SMBIOS Type 17 (Memory Device) structs collected.
+ * Pointers only, so this is cheap; 32 covers 2-socket servers with
+ * 24-32 DIMM slots. Devices beyond the limit are ignored.
+ */
+
+#define MAX_DMI_MEM_DEVICES 32
+
+extern struct mem_dev *dmi_memory_devices[MAX_DMI_MEM_DEVICES];
+extern int dmi_num_memory_devices;
 
 /**
  * Processor Information Structure (SMBIOS type 4)
@@ -180,5 +191,13 @@ int smbios_init(void);
  */
 
 void print_smbios_startup_info(void);
+
+/**
+ * Print per-module memory info from DMI Type 17 structs, as a fallback
+ * when SPD decoding found no module. Prints nothing if no populated
+ * Type 17 struct exists.
+ */
+
+void print_dmi_memory_info(void);
 
 #endif // SMBIOS_H

--- a/system/spd.c
+++ b/system/spd.c
@@ -27,10 +27,19 @@ static inline uint8_t bcd_to_ui8(uint8_t bcd)
     return bcd - 6 * (bcd >> 4);
 }
 
+const char *get_jep106_name(uint16_t jedec_code)
+{
+    for (uint16_t i = 0; i < JEP106_CNT; i++) {
+        if (jedec_code == jep106[i].jedec_code) {
+            return jep106[i].name;
+        }
+    }
+    return NULL;
+}
+
 void print_spdi(spd_info spdi, uint8_t row)
 {
     uint8_t curcol;
-    uint16_t i;
 
     // Print Slot Index, Module Size, type & Max frequency (Jedec or XMP)
     curcol = printf(row, 0, " - Slot %i: %kB %s-%i",
@@ -51,18 +60,14 @@ void print_spdi(spd_info spdi, uint8_t row)
         curcol = prints(row, ++curcol, "EPP");
     }
 
-    // Print Manufacturer from JEDEC106
-    for (i = 0; i < JEP106_CNT; i++) {
-        if (spdi.jedec_code == jep106[i].jedec_code) {
-            curcol = printf(row, ++curcol, "- %s", jep106[i].name);
-            break;
-        }
-    }
+    // Print Manufacturer from JEDEC106, or the raw JEDEC ID if not in the table
+    const char *manufacturer = get_jep106_name(spdi.jedec_code);
 
-    // If not present in JEDEC106, display raw JEDEC ID
-    if (spdi.jedec_code == 0) {
+    if (manufacturer != NULL) {
+        curcol = printf(row, ++curcol, "- %s", manufacturer);
+    } else if (spdi.jedec_code == 0) {
         curcol = prints(row, ++curcol, "- Noname");
-    } else if (i == JEP106_CNT) {
+    } else {
         curcol = printf(row, ++curcol, "- Unknown (0x%x)", spdi.jedec_code);
     }
 

--- a/system/spd.h
+++ b/system/spd.h
@@ -71,4 +71,12 @@ extern ram_slot_info_t ram_slot_info[MAX_SPD_SLOT];
 void print_spdi(spd_info spdi, uint8_t lidx);
 void parse_spd(spd_info *spdi, uint8_t slot_idx);
 
+/**
+ * Return the JEP-106 manufacturer name for a jedec code composed as
+ * (bank << 8 | id), where bank is the number of 0x7F continuation codes
+ * and id is the manufacturer byte with the parity bit stripped.
+ * Return NULL if the code is not in the table.
+ */
+const char *get_jep106_name(uint16_t jedec_code);
+
 #endif // SPD_H

--- a/system/x86/i2c.c
+++ b/system/x86/i2c.c
@@ -41,7 +41,7 @@ static uint8_t nf_read_spd_byte(uint8_t smbus_adr, uint8_t spd_adr);
 static uint8_t ali_m1563_read_spd_byte(uint8_t smbus_adr, uint8_t spd_adr);
 static uint8_t ali_m1543_read_spd_byte(uint8_t smbus_adr, uint8_t spd_adr);
 
-void print_spd_startup_info(void)
+int print_spd_startup_info(void)
 {
     uint8_t spdidx = 0, spd_line_idx = 0;
 
@@ -52,7 +52,7 @@ void print_spd_startup_info(void)
     }
 
     if (!setup_smb_controller() || smbusbase == 0) {
-        return;
+        return 0;
     }
 
     for (spdidx = 0; spdidx < MAX_SPD_SLOT; spdidx++) {
@@ -76,6 +76,8 @@ void print_spd_startup_info(void)
         print_spdi(curspd, ROW_SPD+spd_line_idx);
         spd_line_idx++;
     }
+
+    return spd_line_idx;
 }
 
 // --------------------------


### PR DESCRIPTION
Add a fallback display for systems where SPD is unavailable (LPDDR5/soldered memory, unsupported I2C controllers, servers): populated  SMBIOS/DMI Type 17 records are collected, identical modules grouped, and size/type/configured speed/manufacturer/part number shown in the usual SPD area.

Manufacturer is resolved from the JEDEC module manufacturer ID (SMBIOS 3.2+) via the shared JEP-106 table, with a filtered fallback to  the free-form DMI string. That requires the SMBIOS v3 entry point support cherry-picked from x86fr/aarch64
