### PR TITLE
Hardened AP Stack Management

### DIFF
--- a/app/display.c
+++ b/app/display.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include "cpuid.h"
+#include "cpulocal.h"
 #include "cpuinfo.h"
 #include "hwctrl.h"
 #include "i2c_x86.h"
@@ -15,6 +16,7 @@
 #include "serial.h"
 #include "pmem.h"
 #include "smbios.h"
+#include "smp.h"
 #include "spd.h"
 #include "temperature.h"
 #include "tsc.h"
@@ -539,16 +541,20 @@ void scroll(void)
     if (scroll_message_row < ROW_SCROLL_B) {
         scroll_message_row++;
     } else {
-        if (scroll_lock) {
-            display_footer_message("<Enter> Single step     ");
-        }
-        scroll_wait = true;
-        do {
-            check_input();
-        } while (scroll_wait && scroll_lock);
+        // Only the master CPU may poll the keyboard, so the scroll-lock
+        // single-step wait is only available to it.
+        if (smp_my_cpu_num() == master_cpu) {
+            if (scroll_lock) {
+                display_footer_message("<Enter> Single step     ");
+            }
+            scroll_wait = true;
+            do {
+                check_input();
+            } while (scroll_wait && scroll_lock);
 
-        scroll_wait = false;
-        clear_footer_message();
+            scroll_wait = false;
+            clear_footer_message();
+        }
         scroll_screen_region(ROW_SCROLL_T, 0, ROW_SCROLL_B, SCREEN_WIDTH - 1);
     }
 }
@@ -631,6 +637,15 @@ void do_tick(int my_cpu)
 
     // This only tick one time per second
     if (!timed_update_done) {
+
+        // A corrupted stack canary means a CPU overran its stack slot and may
+        // have corrupted the thread-local barrier flags below it (see boot.h).
+        static int last_overflow_cpu = -1;
+        int overflow_cpu = stack_canary_check();
+        if (overflow_cpu >= 0 && overflow_cpu != last_overflow_cpu) {
+            last_overflow_cpu = overflow_cpu;
+            do_trace(overflow_cpu, "CPU stack overflow detected - test results are unreliable");
+        }
 
         // Display FAIL banner if (new) errors detected
         if (err_banner_redraw && !big_status_displayed && error_count > 1) {

--- a/app/error.c
+++ b/app/error.c
@@ -14,6 +14,7 @@
 #include <limits.h>
 
 #include "smp.h"
+
 #include "vmem.h"
 
 #include "badram.h"
@@ -276,7 +277,11 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
 #endif
         }
         if (new_address) {
-            check_input();
+            // Only the master CPU may poll the keyboard: polling from other
+            // CPUs would race the master's polling.
+            if (smp_my_cpu_num() == master_cpu) {
+                check_input();
+            }
             scroll();
 
             set_foreground_colour(YELLOW);

--- a/app/loongarch/interrupt.c
+++ b/app/loongarch/interrupt.c
@@ -186,7 +186,9 @@ void interrupt(struct system_context *system_context)
 
     ecode = (system_context->estat >> 16) & 0x3F;
 
-    spin_lock(error_mutex);
+    // Don't wait for the error mutex: it may be held by a stopped CPU, or by
+    // this very CPU if the interrupt was taken inside the error reporting path.
+    spin_trylock(error_mutex);
 
     clear_message_area();
 

--- a/app/main.c
+++ b/app/main.c
@@ -21,6 +21,7 @@
 #include "acpi.h"
 #include "cache.h"
 #include "cpuid.h"
+#include "cpulocal.h"
 #include "cpuinfo.h"
 #include "heap.h"
 #include "hwctrl.h"
@@ -33,6 +34,7 @@
 #include "pci.h"
 #include "screen.h"
 #include "serial.h"
+#include "simd.h"
 #include "smbios.h"
 #include "smp.h"
 #include "temperature.h"
@@ -208,6 +210,10 @@ static void global_init(void)
     floppy_off();
 
     cpuid_init();
+
+    simd_init();
+
+    test_list_init();
 
     // Nothing before this should access the boot parameters, in case they are located above 4GB.
     // This is the first region we map, so it is guaranteed not to fail.
@@ -447,6 +453,10 @@ static void test_all_windows(int my_cpu)
         }
     }
     if (i_am_master) {
+        // CPUs not taking part in this test won't re-arm their stack
+        // canaries, and the coming relocations will invalidate them.
+        stack_canary_disarm_all();
+
         num_active_cpus = 1;
         if (!dummy_run) {
             if (parallel_test) {

--- a/app/x86/interrupt.c
+++ b/app/x86/interrupt.c
@@ -202,7 +202,9 @@ ISR_GP_REGS_ONLY void interrupt(struct trap_regs *trap_regs)
         }
     }
 
-    spin_lock(error_mutex);
+    // Don't wait for the error mutex: it may be held by a stopped CPU, or by
+    // this very CPU if the interrupt was taken inside the error reporting path.
+    spin_trylock(error_mutex);
 
     clear_message_area();
 

--- a/boot/boot.h
+++ b/boot/boot.h
@@ -19,11 +19,16 @@
 #define	MAX_APS		511		/* Maximum number of active APs */
 
 #define BSP_STACK_SIZE	16384		/* Stack size for the BSP */
-#ifdef __loongarch_lp64
-#define AP_STACK_SIZE	2048		/* Stack size for each AP */
-#else
-#define AP_STACK_SIZE	1024		/* Stack size for each AP */
-#endif
+
+/*
+ * Stack size for each AP. Each CPU's thread-local storage (the barrier
+ * waiting flags) occupies the top LOCALS_SIZE bytes of its own stack slot,
+ * directly below the bottom of the next CPU's stack: an AP overrunning its
+ * stack silently corrupts its neighbour's flags and freezes the whole test.
+ * 1024 bytes proved too small for the error reporting path; the canary in
+ * system/cpulocal.c turns any future overrun into a visible report.
+ */
+#define AP_STACK_SIZE	2048
 
 #define	STACKS_SIZE	(BSP_STACK_SIZE + MAX_APS * AP_STACK_SIZE)
 

--- a/lib/spinlock.h
+++ b/lib/spinlock.h
@@ -71,6 +71,18 @@ static inline void spin_lock(spinlock_t *lock)
 }
 
 /**
+ * Locks the mutex if it is not currently locked, without waiting. Returns
+ * true if the mutex was locked by this call, false if it was already held.
+ */
+static inline bool spin_trylock(spinlock_t *lock)
+{
+    if (lock) {
+        return __sync_bool_compare_and_swap(lock, false, true);
+    }
+    return true;
+}
+
+/**
  * Unlocks the mutex.
  */
 static inline void spin_unlock(spinlock_t *lock)

--- a/system/cpulocal.c
+++ b/system/cpulocal.c
@@ -2,16 +2,42 @@
 // Copyright (C) 2022 Martin Whitaker.
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "boot.h"
+#include "smp.h"
 
 #include "cpulocal.h"
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+// An arbitrary value that is unlikely to appear in a stack frame.
+#define STACK_CANARY    UINT32_C(0x446D6153)
 
 //------------------------------------------------------------------------------
 // Variables
 //------------------------------------------------------------------------------
 
 int local_bytes_used = 0;
+
+// Whether each stack canary is currently valid. The stack area is not
+// preserved across program relocations, hence the arm/disarm cycle.
+static bool canary_armed[MAX_CPUS];
+
+//------------------------------------------------------------------------------
+// Private Functions
+//------------------------------------------------------------------------------
+
+static uint32_t *stack_canary_addr(int cpu_num)
+{
+    uintptr_t slot_bottom = (uintptr_t)_stacks;
+    if (cpu_num > 0) {
+        slot_bottom += BSP_STACK_SIZE + (uintptr_t)(cpu_num - 1) * AP_STACK_SIZE;
+    }
+    return (uint32_t *)slot_bottom;
+}
 
 //------------------------------------------------------------------------------
 // Public Functions
@@ -23,4 +49,30 @@ int allocate_local_flag(void)
         return -1;
     }
     return local_bytes_used += sizeof(bool);
+}
+
+void stack_canary_arm(int cpu_num)
+{
+    if (cpu_num < 0 || cpu_num >= MAX_CPUS) {
+        return;
+    }
+    *stack_canary_addr(cpu_num) = STACK_CANARY;
+    canary_armed[cpu_num] = true;
+}
+
+void stack_canary_disarm_all(void)
+{
+    for (int i = 0; i < MAX_CPUS; i++) {
+        canary_armed[i] = false;
+    }
+}
+
+int stack_canary_check(void)
+{
+    for (int i = 0; i < num_available_cpus; i++) {
+        if (canary_armed[i] && *stack_canary_addr(i) != STACK_CANARY) {
+            return i;
+        }
+    }
+    return -1;
 }

--- a/system/cpulocal.h
+++ b/system/cpulocal.h
@@ -43,4 +43,21 @@ static inline local_flag_t *local_flags(int flag_num)
     return (local_flag_t *)(_stacks + BSP_STACK_SIZE - LOCALS_SIZE + flag_num);
 }
 
+/**
+ * Writes a canary value at the bottom of the given CPU's stack slot and
+ * marks it as armed. Must be called again after each program relocation.
+ */
+void stack_canary_arm(int cpu_num);
+
+/**
+ * Marks all stack canaries as no longer valid.
+ */
+void stack_canary_disarm_all(void);
+
+/**
+ * Checks all armed stack canaries. Returns the number of the first CPU
+ * whose canary has been overwritten, or -1 if all are intact.
+ */
+int stack_canary_check(void);
+
 #endif // CPULOCAL_H

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (C) 2020-2022 Martin Whitaker.
+// Copyright (C) 2004-2026 Sam Demeulemeester.
 //
-// Derived from an extract of memtest86+ main.c:
-//
-// MemTest86+ V5 Specific code (GPL V2.0)
-// By Samuel DEMEULEMEESTER, sdemeule@memtest.org
-// http://www.canardpc.com - http://www.memtest.org
 // ------------------------------------------------
 // main.c - MemTest-86  Version 3.5
 //
@@ -19,7 +15,9 @@
 
 #include "cache.h"
 #include "cpuid.h"
+#include "cpulocal.h"
 #include "memsize.h"
+#include "simd.h"
 #include "tsc.h"
 #include "vmem.h"
 
@@ -44,6 +42,9 @@
 
 #define MODULO_N            20
 
+// The test whose description is patched with the SIMD tier by test_list_init().
+#define MOV_INV_RNG_TEST    4
+
 //------------------------------------------------------------------------------
 // Public Variables
 //------------------------------------------------------------------------------
@@ -54,17 +55,18 @@ test_pattern_t test_list[NUM_TEST_PATTERNS] = {
     {false,  ONE,    1,    6,    0, "[Address test, own address in window]  "},
     { true,  ONE,    2,    6,    0, "[Address test, own address + window]   "},
     { true,  PAR,    1,    6,    0, "[Moving inversions, 1s & 0s]           "},
+    { true,  PAR,    1,  128,    0, "[Moving inversions, random sequence]   "},
     { true,  PAR,    1,    3,    0, "[Moving inversions, 8 bit pattern]     "},
-    { true,  PAR,    1,   30,    0, "[Moving inversions, random pattern]    "},
-#if TESTWORD_WIDTH > 32
-    { true,  PAR,    1,    3,    0, "[Moving inversions, 64 bit pattern]    "},
-#else
-    { true,  PAR,    1,    3,    0, "[Moving inversions, 32 bit pattern]    "},
-#endif
+    { true,  PAR,    1,    8,    0, "[Modulo 20, random pattern]            "},
     { true,  PAR,    1,   81,    0, "[Block move]                           "},
-    { true,  PAR,    1,   48,    0, "[Random number sequence]               "},
-    { true,  PAR,    1,    6,    0, "[Modulo 20, random pattern]            "},
-    { true,  ONE,    6,  240,    0, "[Bit fade test, 2 patterns]            "},
+#if TESTWORD_WIDTH > 32
+    { true,  PAR,    1,    1,    0, "[Moving inversions, 64 bit pattern]    "},
+#else
+    { true,  PAR,    1,    1,    0, "[Moving inversions, 32 bit pattern]    "},
+#endif
+    { true,  PAR,    1,   32,    0, "[Bus stress, R/W turnaround, random]   "},
+    { true,  PAR,   12,  120,    0, "[Bit fade test, 0s, 1s, random]        "},
+    {false,  ONE,    1,   24,    0, "[Rowhammer, Blacksmith-style]          "},
 };
 
 int ticks_per_pass[NUM_PASS_TYPES];
@@ -89,8 +91,42 @@ int ticks_per_test[NUM_PASS_TYPES][NUM_TEST_PATTERNS];
         } \
     }
 
+void test_list_init(void)
+{
+    const char *tier_name = simd_tier_name();
+
+    if (tier_name == NULL) {
+        // Keep the generic description from the table.
+        return;
+    }
+
+    // Rewrite the description to show the SIMD tier used by the test,
+    // e.g. "[Moving inversions, random (AVX2)]".
+    const char *prefix = "[Moving inversions, random (";
+    char *desc = test_list[MOV_INV_RNG_TEST].description;
+
+    int i = 0;
+    while (prefix[i] != '\0') {
+        desc[i] = prefix[i];
+        i++;
+    }
+    for (int j = 0; tier_name[j] != '\0'; j++) {
+        desc[i++] = tier_name[j];
+    }
+    desc[i++] = ')';
+    desc[i++] = ']';
+    while (i < (int)sizeof(test_list[MOV_INV_RNG_TEST].description) - 1) {
+        desc[i++] = ' ';
+    }
+    desc[i] = '\0';
+}
+
 int run_test(int my_cpu, int test, int stage, int iterations)
 {
+    // (Re)arm the canary guarding against this CPU overrunning its stack.
+    // Needed on every call: relocation invalidates the stack area.
+    stack_canary_arm(my_cpu);
+
     if (my_cpu == master_cpu) {
         if (window_num == 0) {
             // First window, so we need to test all selected lower memory.
@@ -148,8 +184,21 @@ int run_test(int my_cpu, int test, int stage, int iterations)
         BAILOUT;
       } break;
 
+        // Moving inversions, pseudo-random sequence (SIMD where available).
+        // Every fourth round broadcasts a single random value to all vector
+        // lanes, preserving the uniform-background model of the classic
+        // random pattern test. Runs early: it has the highest fault
+        // detection rate per second, so this minimises time to first fault.
+      case 4:
+        for (int i = 0; i < iterations; i++) {
+            BARRIER;
+            ticks += test_mov_inv_rng(my_cpu, (i & 3) == 3);
+            BAILOUT;
+        }
+        break;
+
         // Moving inversions, 8 bit walking ones and zeros.
-      case 4: {
+      case 5: {
 #if TESTWORD_WIDTH > 32
             testword_t pattern1 = UINT64_C(0x8080808080808080);
 #else
@@ -170,57 +219,10 @@ int run_test(int my_cpu, int test, int stage, int iterations)
         }
       } break;
 
-        // Moving inversions, fixed random pattern.
-      case 5:
-        if (cpuid_info.flags.rdtsc) {
-            prsg_state = get_tsc();
-        } else {
-            prsg_state = 1 + pass_num;
-        }
-        prsg_state *= 0x12345678;
-
-        for (int i = 0; i < iterations; i++) {
-            prsg_state = prsg(prsg_state);
-
-            testword_t pattern1 = prsg_state;
-            testword_t pattern2 = ~pattern1;
-
-            BARRIER;
-            ticks += test_mov_inv_fixed(my_cpu, 2, pattern1, pattern2);
-            BAILOUT;
-        }
-        break;
-
-        // Moving inversions, 32/64 bit shifting pattern.
+        // Modulo 20 check, fixed random pattern. Runs before the long
+        // shifting pattern test: it is the only test immune to cache
+        // masking, so every fault class has been probed early in the pass.
       case 6:
-        for (int offset = 0; offset < TESTWORD_WIDTH; offset++) {
-            BARRIER;
-            ticks += test_mov_inv_walk1(my_cpu, iterations, offset, false);
-            BAILOUT;
-
-            BARRIER;
-            ticks += test_mov_inv_walk1(my_cpu, iterations, offset, true);
-            BAILOUT;
-        }
-        break;
-
-        // Block move.
-      case 7:
-        ticks += test_block_move(my_cpu, iterations);
-        BAILOUT;
-        break;
-
-        // Moving inversions, fully random patterns.
-      case 8:
-        for (int i = 0; i < iterations; i++) {
-            BARRIER;
-            ticks += test_mov_inv_random(my_cpu);
-            BAILOUT;
-        }
-        break;
-
-        // Modulo 20 check, fixed random pattern.
-      case 9:
         if (cpuid_info.flags.rdtsc) {
             prsg_state = get_tsc();
         } else {
@@ -246,9 +248,61 @@ int run_test(int my_cpu, int test, int stage, int iterations)
         }
         break;
 
-        // Bit fade test.
+        // Block move.
+      case 7:
+        ticks += test_block_move(my_cpu, iterations);
+        BAILOUT;
+        break;
+
+        // Moving inversions, 32/64 bit shifting pattern. A single iteration
+        // per pass suffices: the patterns are deterministic, so repeating
+        // them within a pass adds nothing that the next pass doesn't. On the
+        // fast first pass only every other offset is walked; full coverage
+        // is restored on every full pass.
+      case 8: {
+        if (iterations < 1) {
+            iterations = 1;     // the first pass divides the table value by 3
+        }
+        int offset_step = (pass_num == 0) ? 2 : 1;
+        for (int offset = 0; offset < TESTWORD_WIDTH; offset += offset_step) {
+            BARRIER;
+            ticks += test_mov_inv_walk1(my_cpu, iterations, offset, false);
+            BAILOUT;
+
+            BARRIER;
+            ticks += test_mov_inv_walk1(my_cpu, iterations, offset, true);
+            BAILOUT;
+        }
+      } break;
+
+        // Bus stress: NT-write/read burst interleave between two half-chunk streams, duty-cycled
+        // on odd rounds to provoke PMIC load steps. Runs before bit fade so the DIMMs enter it hot.
+      case 9:
+        if (iterations < 1) {
+            iterations = 1;     // the first pass divides the table value by 3
+        }
+        for (int i = 0; i < iterations; i++) {
+            BARRIER;
+            ticks += test_bus_stress(my_cpu, i);
+            BAILOUT;
+        }
+        break;
+
+        // Bit fade test: four fill/fade/check rounds - solid zeros, solid ones, then an
+        // address-seeded random pattern and its complement. `iterations` = fade seconds per round.
       case 10:
         ticks += test_bit_fade(my_cpu, stage, iterations);
+        BAILOUT;
+        break;
+
+        // Rowhammer test: Blacksmith-style non-uniform, REFRESH-synchronised,
+        // many-sided hammering of a time-boxed sample of sites. Disabled by
+        // default. Runs on a single core (ONE): the DRAM flips regardless of
+        // which core hammers, so per-core repetition would only multiply the
+        // runtime, and a lone core keeps activation timing clean.
+        // `iterations` = seconds budget. See tests/rowhammer.c.
+      case 11:
+        ticks += test_rowhammer(my_cpu, iterations);
         BAILOUT;
         break;
     }


### PR DESCRIPTION
Fix SMP freeze when a worker CPU reports memory errors (AP stack overflow)

On SMP runs with a defective DIMM, the test froze completely (spinner and  keyboard dead) after a variable number of reported errors, on any test. Issue is present in v8.10.

Each CPU's thread-local storage (the halt-barrier waiting flags) occupies the top LOCALS_SIZE bytes of its own stack slot, directly below the bottom of the next CPU's stack. The error reporting path (error mutex + scroll + printf + screen rendering + keyboard polling) needs more than the 1024 bytes an AP stack provided, so a reporting AP overran its slot and overwrote its neighbour's barrier flags with stack garbage. The releasing CPU then either skipped the victim's wakeup NMI, or the victim read a garbage flag and treated its wakeup as stale: one CPU slept forever in HLT and every other CPU deadlocked on the next barrier. Single-CPU runs were immune because the BSP has a 16KB stack.

- Increase AP_STACK_SIZE from 1024 to 2048 bytes (matching LoongArch/Aarch64)
- Add a canary at the bottom of each CPU's stack slot, checked once per second by the master, so a future overrun is reported on screen instead of deadlocking silently ***--- Performance penalty under evaluation ---***
-  Only poll the keyboard from the master CPU in the error reporting and scroll-lock paths; this also removes the deepest stack frames (USB keyboard polling) from the workers' error path
- Use spin_trylock() on the error mutex in the unexpected-interrupt handler, so a trap taken while the mutex is held reports instead of hanging