### PR TITLE
implement serial console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ recognised:
       * mmio16 = 16-bit MMIO
       * mmio32 = 32-bit MMIO
     * and *y* is the MMIO address in hex. with `0x` prefix (eg: 0xFEDC9000)
+  * log=ttyS*x*,*y*
+  * log=*x*,*y*
+    * log status/progress to serial/tty/UART console.
+    * takes the same parameters as console.
+    * mutually exclusive with console.
   * newline
     * modifies the console to print a newline after every change to the frame buffer
       * useful in logging over serial where an escape or newline is needed

--- a/app/config.c
+++ b/app/config.c
@@ -111,6 +111,7 @@ bool            dark_mode          = false;
 power_save_t    power_save         = POWER_SAVE_HIGH;
 
 bool            enable_tty         = false;
+bool            enable_tty_log     = false;
 uintptr_t       tty_address        = 0x3F8;             // Legacy IO or MMIO Address accepted
 int             tty_baud_rate      = 115200;
 int             tty_update_period  = 2;                 // Update TTY every 2 seconds (default)
@@ -128,8 +129,6 @@ bool            err_banner_redraw  = false;             // Redraw banner on new 
 
 static void parse_serial_params(const char *params)
 {
-    enable_tty = true;
-
     // No parameters passed (only "console"), use default
      if (params == NULL) {
         return;
@@ -297,6 +296,16 @@ static void parse_option(const char *option, const char *params)
     if (params == NULL) params = "";
 
     if (strncmp(option, "console", 8) == 0) {
+        enable_tty = true;
+        if (enable_tty_log) {
+            enable_tty_log = false;
+        }
+        parse_serial_params(params);
+    } else if (strncmp(option, "log", 4) == 0) {
+        enable_tty_log = true;
+        if (enable_tty) {
+            enable_tty = false;
+        }
         parse_serial_params(params);
     } else if (strncmp(option, "newline", 7) == 0) {
         tty_new_line = true;

--- a/app/config.h
+++ b/app/config.h
@@ -61,6 +61,7 @@ extern bool         enable_temp_ram;
 
 extern bool         enable_sm;
 extern bool         enable_tty;
+extern bool         enable_tty_log;
 extern bool         enable_bench;
 extern bool         enable_mch_read;
 extern bool         enable_ecc_polling;

--- a/app/display.c
+++ b/app/display.c
@@ -22,6 +22,7 @@
 #include "tsc.h"
 
 #include "barrier.h"
+#include "log.h"
 #include "spinlock.h"
 
 #include "config.h"
@@ -603,25 +604,25 @@ void do_tick(int my_cpu)
 
     pass_type_t pass_type = (pass_num == 0) ? FAST_PASS : FULL_PASS;
 
-    int pct = 0;
+    int test_pct = 0;
     if (ticks_per_test[pass_type][test_num] > 0) {
-        pct = 100 * test_ticks / ticks_per_test[pass_type][test_num];
-        if (pct > 100) {
-            pct = 100;
+        test_pct = 100 * test_ticks / ticks_per_test[pass_type][test_num];
+        if (test_pct > 100) {
+            test_pct = 100;
         }
     }
-    display_test_percentage(pct);
-    display_test_bar((BAR_LENGTH * pct) / 100);
+    display_test_percentage(test_pct);
+    display_test_bar((BAR_LENGTH * test_pct) / 100);
 
-    pct = 0;
+    int pass_pct = 0;
     if (ticks_per_pass[pass_type] > 0) {
-        pct = 100 * pass_ticks / ticks_per_pass[pass_type];
-        if (pct > 100) {
-            pct = 100;
+        pass_pct = 100 * pass_ticks / ticks_per_pass[pass_type];
+        if (pass_pct > 100) {
+            pass_pct = 100;
         }
     }
-    display_pass_percentage(pct);
-    display_pass_bar((BAR_LENGTH * pct) / 100);
+    display_pass_percentage(pass_pct);
+    display_pass_bar((BAR_LENGTH * pass_pct) / 100);
 
     bool update_spinner = true;
     if (clks_per_msec > 0) {
@@ -677,6 +678,12 @@ void do_tick(int my_cpu)
 
             if (act_sec % tty_update_period == 0) {
                 tty_partial_redraw();
+            }
+        }
+
+        if (enable_tty_log) {
+            if (act_sec % tty_update_period == 0) {
+                tty_log("pass %i (%i%%) test %i (%i%%)\r\n", pass_num, pass_pct, test_num, test_pct);
             }
         }
 

--- a/app/error.c
+++ b/app/error.c
@@ -22,6 +22,8 @@
 #include "display.h"
 #include "test.h"
 
+#include "log.h"
+
 #include "tests.h"
 #include "serial.h"
 #include "memctrl.h"
@@ -289,18 +291,26 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
             display_scrolled_message(0, " %2i   %4i   %2i   %09x%03x (%kB)",
                                      type != CECC_ERROR ? smp_my_cpu_num() : ecc_status.core,
                                      pass_num, test_num, page, offset, page << 2);
+            tty_log("ERROR: pCPU:%i Pass:%i Test:%i Address:%x%x (%kB) ",
+                    type != CECC_ERROR ? smp_my_cpu_num() : ecc_status.core,
+                    pass_num, test_num, page, offset, page << 2);
 
             if (type == PARITY_ERROR) {
                 display_scrolled_message(41, "%s", "Parity error detected near this address");
+                tty_log("%s", "Parity error detected near this address");
             } else if (type == CECC_ERROR) {
                 display_scrolled_message(41, "%s%2i", "Correctable ECC Error - CH#", ecc_status.channel);
+                tty_log("%s%i", "Correctable ECC Error - CH#", ecc_status.channel);
             } else {
 #if TESTWORD_WIDTH > 32
                 display_scrolled_message(41, "%016x  %016x", good, bad);
+                tty_log("good:%x  bad:%x", good, bad);
 #else
                 display_scrolled_message(41, "%08x  %08x  %08x  %i", good, bad, xor, error_count);
+                tty_log("good:%x bad:%x xor:%x count:%i", good, bad, xor, error_count);
 #endif
             }
+            tty_log("\r\n");
 
             set_foreground_colour(WHITE);
 

--- a/app/main.c
+++ b/app/main.c
@@ -41,6 +41,7 @@
 #include "timers.h"
 #include "vmem.h"
 
+#include "log.h"
 #include "unistd.h"
 
 #include "badram.h"
@@ -48,6 +49,7 @@
 #include "display.h"
 #include "error.h"
 #include "test.h"
+#include "version.h"
 
 #include "tests.h"
 
@@ -681,6 +683,16 @@ void main(void)
         cache_on();
         if (my_cpu == 0) {
             global_init();
+            tty_log("\r\n");
+            tty_log("Memtest86+ v" MT_VERSION "." GIT_HASH);
+#if defined (__x86_64__)
+            tty_log(".x64");
+#elif defined (__i386__)
+            tty_log(".x32");
+#elif defined (__loongarch_lp64)
+            tty_log(".la64");
+#endif
+            tty_log("\r\n");
             init_state = 1;
             if (enable_trace && num_enabled_cpus > 1) {
                 set_scroll_lock(false);
@@ -749,6 +761,7 @@ void main(void)
                     ticks_per_test[pass_num][test_num] = 0;
                 } else if (test_list[test_num].enabled) {
                     display_start_test();
+                    tty_log("start pass %i test %i\r\n", pass_num, test_num);
                 }
                 bail = false;
             }
@@ -836,8 +849,10 @@ void main(void)
             display_pass_count(pass_num);
             if (error_count == 0) {
                 display_status("Pass   ");
+                tty_log("Test Result: PASS\r\n");
                 display_big_status(true);
             } else {
+                tty_log("Test Result: FAIL (%u errors)\r\n", error_count);
                 display_big_status(false);
             }
         }

--- a/build/aarch64/Makefile
+++ b/build/aarch64/Makefile
@@ -72,6 +72,7 @@ IMC_SRCS = $(wildcard ../../system/imc/aarch64/*.c)
 IMC_OBJS = $(subst ../../,,$(IMC_SRCS:.c=.o))
 
 LIB_OBJS = lib/barrier.o \
+           lib/log.o \
            lib/print.o \
            lib/read.o \
            lib/string.o \

--- a/build/i586/Makefile
+++ b/build/i586/Makefile
@@ -64,6 +64,7 @@ IMC_SRCS = $(wildcard ../../system/imc/x86/*.c)
 IMC_OBJS = $(subst ../../,,$(IMC_SRCS:.c=.o))
 
 LIB_OBJS = lib/barrier.o \
+           lib/log.o \
            lib/div64.o \
            lib/print.o \
            lib/read.o \

--- a/build/loongarch64/Makefile
+++ b/build/loongarch64/Makefile
@@ -61,6 +61,7 @@ IMC_SRCS = $(wildcard ../../system/imc/loongarch/*.c)
 IMC_OBJS = $(subst ../../,,$(IMC_SRCS:.c=.o))
 
 LIB_OBJS = lib/barrier.o \
+           lib/log.o \
            lib/print.o \
            lib/read.o \
            lib/string.o \

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -63,6 +63,7 @@ IMC_SRCS = $(wildcard ../../system/imc/x86/*.c)
 IMC_OBJS = $(subst ../../,,$(IMC_SRCS:.c=.o))
 
 LIB_OBJS = lib/barrier.o \
+           lib/log.o \
            lib/print.o \
            lib/read.o \
            lib/string.o \

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (C) 2025 classabbyamp.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "serial.h"
+
+#include "string.h"
+
+#include "log.h"
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+#define BUFFER_SIZE 64
+
+//------------------------------------------------------------------------------
+// Private Functions
+//------------------------------------------------------------------------------
+
+static int int_to_dec_str(char buffer[], int value, int max_length)
+{
+    char temp[max_length];
+    bool negative = (value < 0);
+    if (negative) {
+        value = -value;
+        max_length--;
+    }
+
+    int length = 0;
+
+    if (value == 0) {
+        temp[length++] = '0';
+    }
+
+    while (value > 0 && length < max_length) {
+        temp[length++] = '0' + (value % 10);
+        value /= 10;
+    }
+    if (negative) {
+        temp[length++] = '-';
+    }
+    for (int i = length; i > 0; i--) {
+        buffer[length - i] = temp[i - 1];
+    }
+    return length;
+}
+
+static int uint_to_dec_str(char buffer[], uintptr_t value, int max_length)
+{
+    char temp[max_length];
+    int length = 0;
+
+    if (value == 0) {
+        temp[length++] = '0';
+    }
+
+    while (value > 0 && length < max_length) {
+        temp[length++] = '0' + (value % 10);
+        value /= 10;
+    }
+    for (int i = length; i > 0; i--) {
+        buffer[length - i] = temp[i - 1];
+    }
+    return length;
+}
+
+static int uint_to_hex_str(char buffer[], uintptr_t value, int max_length)
+{
+    char temp[max_length];
+    int length = 0;
+
+    if (value == 0) {
+        temp[length++] = '0';
+    }
+
+    while (value > 0 && length < max_length) {
+        int digit = value % 16;
+        if (digit < 10) {
+            temp[length++] = '0' + digit;
+        } else {
+            temp[length++] = 'a' + digit - 10;
+        }
+        value /= 16;
+    }
+    for (int i = length; i > 0; i--) {
+        buffer[length - i] = temp[i - 1];
+    }
+    return length;
+}
+
+//------------------------------------------------------------------------------
+// Public Functions
+//------------------------------------------------------------------------------
+
+void log_printc(const char c)
+{
+    tty_echo_print(&c);
+}
+
+void log_prints(const char *str)
+{
+    tty_echo_print(str);
+}
+
+void log_printi(int value)
+{
+    char buffer[BUFFER_SIZE];
+    memset(buffer, 0, BUFFER_SIZE);
+    int_to_dec_str(buffer, value, BUFFER_SIZE);
+    log_prints(buffer);
+}
+
+void log_printu(uintptr_t value)
+{
+    char buffer[BUFFER_SIZE];
+    memset(buffer, 0, BUFFER_SIZE);
+    uint_to_dec_str(buffer, value, BUFFER_SIZE);
+    log_prints(buffer);
+}
+
+void log_printx(uintptr_t value)
+{
+    char buffer[BUFFER_SIZE];
+    memset(buffer, 0, BUFFER_SIZE);
+    uint_to_hex_str(buffer, value, BUFFER_SIZE);
+    log_prints(buffer);
+}
+
+void log_printk(uintptr_t value)
+{
+    static const char suffix[4] = { 'K', 'M', 'G', 'T' };
+
+    int scale = 0;
+    int fract = 0;
+    while (value >= 1024 && scale < (int)(sizeof(suffix) - 1)) {
+        fract = value % 1024;
+        value /= 1024;
+        scale++;
+    }
+    int fract_length = 0;
+    if (fract > 0) {
+        if (value < 10) {
+            fract = (100 * fract) / 1024;
+            if (fract > 0) {
+                if (fract % 10) {
+                    fract_length = 2;
+                } else {
+                    fract_length = 1;
+                    fract /= 10;
+                }
+            }
+        } else if (value < 100) {
+            fract = (100 * fract) / (10 * 1024);
+            if (fract > 0) {
+                fract_length = 1;
+            }
+        }
+    }
+
+    char buffer[BUFFER_SIZE];
+    memset(buffer, 0, BUFFER_SIZE);
+
+    int length = 0;
+
+    length += uint_to_dec_str(&buffer[length], value, BUFFER_SIZE);
+
+    if (fract_length > 0) {
+        buffer[length++] = '.';
+        length += int_to_dec_str(&buffer[length], fract, BUFFER_SIZE - length);
+    }
+
+    buffer[length++] = suffix[scale];
+
+    log_prints(buffer);
+}
+
+void log_printf(const char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    log_vprintf(fmt, args);
+    va_end(args);
+}
+
+void log_vprintf(const char *fmt, va_list args)
+{
+    while (*fmt) {
+        if (*fmt != '%') {
+            log_printc(*fmt++);
+            continue;
+        }
+        fmt++;
+        if (*fmt == '%') {
+            log_printc(*fmt++);
+            continue;
+        }
+
+        int length = 0;
+        if (*fmt == '*') {
+            length = va_arg(args, int);
+            fmt++;
+        } else {
+            while (*fmt >= '0' && *fmt <= '9') {
+                length = 10 * length + *fmt - '0';
+                fmt++;
+            }
+        }
+        switch (*fmt) {
+          case 'c': {
+            char buffer[1];
+            buffer[0] = va_arg(args, int);
+            log_prints(buffer);
+          } break;
+          case 's': {
+            const char *str = va_arg(args, char *);
+            log_prints(str);
+          } break;
+          case 'i':
+            log_printi(va_arg(args, int));
+            break;
+          case 'u':
+            log_printu(va_arg(args, uintptr_t));
+            break;
+          case 'x':
+            log_printx(va_arg(args, uintptr_t));
+            break;
+          case 'k':
+            log_printk(va_arg(args, uintptr_t));
+            break;
+        }
+        fmt++;
+    }
+}

--- a/lib/log.h
+++ b/lib/log.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef LOG_H
+#define LOG_H
+/**
+ * \file
+ *
+ * Provides functions to print strings and formatted values to the serial tty.
+ *
+ *//*
+ * Copyright (C) 2025 classabbyamp.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define tty_log(...) \
+    if (enable_tty_log) log_printf(__VA_ARGS__)
+
+/**
+ * Prints a single character on serial tty.
+ */
+void log_printc(char c);
+
+/**
+ * Prints a string on serial tty.
+ */
+void log_prints(const char *str);
+
+/**
+ * Prints a signed decimal number on serial tty.
+ */
+void log_printi(int value);
+
+/**
+ * Prints an unsigned decimal number on serial tty.
+ */
+void log_printu(uintptr_t value);
+
+/**
+ * Prints an unsigned hexadecimal number on serial tty.
+ */
+void log_printx(uintptr_t value);
+
+/**
+ * Prints a K<unit> value on serial tty. The value is shown to 3 significant
+ * figures in the nearest K/M/G/T units.
+ */
+void log_printk(uintptr_t value);
+
+/**
+ * Emulates the standard printf function.
+ *
+ * The conversion specifiers supported are:
+ *   c  character (int type)
+ *   s  string (char* type)
+ *   i  signed decimal integer (int type)
+ *   u  unsigned decimal integer (uintptr_t type)
+ *   x  unsigned hexadecimal integer (uintptr_t type)
+ *   k  K<unit> value (scaled to K/M/G/T) (uintptr_t type)
+ */
+void log_printf(const char *fmt, ...);
+
+/**
+ * The alternate form of printf.
+ */
+void log_vprintf(const char *fmt, va_list args);
+
+#endif // LOG_H
+

--- a/system/serial.c
+++ b/system/serial.c
@@ -110,7 +110,7 @@ static void tty_goto(int y, int x)
 
 void tty_init(void)
 {
-    if (!enable_tty) {
+    if (!(enable_tty || enable_tty_log)) {
         return;
     }
 
@@ -181,8 +181,10 @@ void tty_init(void)
         serial_write_reg(&console_serial, UART_FCR, (0xFF) & (UART_FCR_ENA | UART_FCR_THR));
     }
 
-    tty_clear_screen();
-    tty_disable_cursor();
+    if (enable_tty) {
+        tty_clear_screen();
+        tty_disable_cursor();
+    }
 }
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col)
@@ -291,4 +293,8 @@ char tty_get_char(int max_wait_frames)
     } while (wait_time > 0);
 
     return '\0';
+}
+
+void tty_echo_print(const char *p) {
+    serial_echo_print(p);
 }

--- a/system/serial.h
+++ b/system/serial.h
@@ -193,4 +193,6 @@ void tty_send_region(int start_row, int start_col, int end_row, int end_col);
 
 char tty_get_char(int max_wait_frames);
 
+void tty_echo_print(const char *p);
+
 #endif /* _SERIAL_REG_H */


### PR DESCRIPTION
I use memtest86+ for some automated testing of RAM, and the best way I've found to exfiltrate the results has been via logging progress, errors, and results to a serial console. The existing `console` option was not easily machine-parsable, because it did lots of moving around the console and redrawing things.

To enable serial logging, I used a command-line option similar to `console`, and because `log` and `console` both use the serial console, they are made mutually exclusive.

<img width="1920" height="1099" alt="image" src="https://github.com/user-attachments/assets/99cf8bde-5121-4069-ac8b-cf0481cbc88f" />

(screenshot from an older version, but I've tested it on the latest HEAD of `main`)

example logs:
```
Memtest86+ v8.00.unknown.x64
start pass 0 test 0
pass 0 (0%) test 0 (1%)
pass 0 (0%) test 0 (3%)
start pass 0 test 2
pass 0 (0%) test 2 (15%)
pass 0 (0%) test 2 (30%)
pass 0 (0%) test 2 (40%)
pass 0 (0%) test 2 (50%)
[...]
pass 0 (99%) test 10 (83%)
pass 0 (99%) test 10 (84%)
pass 0 (99%) test 10 (85%)
pass 0 (99%) test 10 (85%)
pass 0 (99%) test 10 (86%)
pass 0 (99%) test 10 (87%)
pass 0 (99%) test 10 (88%)
pass 0 (99%) test 10 (88%)
pass 0 (99%) test 10 (89%)
pass 0 (99%) test 10 (94%)
pass 0 (99%) test 10 (97%)
Test Result: PASS
Done, rebooting
```

I've been testing this on Dell servers with iDRAC serial over LAN for several months without issue.