### PR TITLE
Add a machine-parseable serial log ("log" boot option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ recognised:
     * modifies the console to print a newline after every change to the frame buffer
       * useful in logging over serial where an escape or newline is needed
     * only used when using console/serial output
+  * log=*x*,*y*
+    * activate the machine-parseable serial log instead of the interactive
+      serial console, using the same *x*,*y* parameters as `console=`
+    * outputs one `MTLOG ts=<seconds> ev=<event> key=value ...` line per event
+      (start banner, system info, pass/test lifecycle, timed progress, errors)
+    * mutually exclusive with `console=`; if both are given, `log` wins
   * testlist=*x,y,z*
     * where *x,y,z* is a list of the numerical values of the tests to run.
     * if specified, the initial test configuration is modified such that only the

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ recognised:
     * outputs one `MTLOG ts=<seconds> ev=<event> key=value ...` line per event
       (start banner, system info, pass/test lifecycle, timed progress, errors)
     * mutually exclusive with `console=`; if both are given, `log` wins
+  * maxpasses=*n*
+    * stop after *n* completed passes: emit a final `ev=done` line, then reboot
+    * only used in `log` mode; 0 = unlimited (default)
   * testlist=*x,y,z*
     * where *x,y,z* is a list of the numerical values of the tests to run.
     * if specified, the initial test configuration is modified such that only the

--- a/app/config.c
+++ b/app/config.c
@@ -111,6 +111,7 @@ bool            dark_mode          = false;
 power_save_t    power_save         = POWER_SAVE_HIGH;
 
 bool            enable_tty         = false;
+bool            enable_tty_log     = false;             // Machine-parseable serial log instead of interactive console
 uintptr_t       tty_address        = 0x3F8;             // Legacy IO or MMIO Address accepted
 int             tty_baud_rate      = 115200;
 int             tty_update_period  = 2;                 // Update TTY every 2 seconds (default)
@@ -298,6 +299,9 @@ static void parse_option(const char *option, const char *params)
 
     if (strncmp(option, "console", 8) == 0) {
         parse_serial_params(params);
+    } else if (strncmp(option, "log", 4) == 0) {
+        parse_serial_params(params);
+        enable_tty_log = enable_tty;
     } else if (strncmp(option, "newline", 7) == 0) {
         tty_new_line = true;
     } else if (strncmp(option, "cpuseqmode", 11) == 0) {
@@ -1010,6 +1014,11 @@ void config_init(void)
         if (cmd_line_addr != 0) {
             parse_command_line((char *)cmd_line_addr, cmd_line_size);
         }
+    }
+
+    // Serial log mode replaces the interactive serial console.
+    if (enable_tty_log) {
+        enable_tty = false;
     }
 }
 

--- a/app/config.c
+++ b/app/config.c
@@ -112,6 +112,7 @@ power_save_t    power_save         = POWER_SAVE_HIGH;
 
 bool            enable_tty         = false;
 bool            enable_tty_log     = false;             // Machine-parseable serial log instead of interactive console
+int             log_max_passes     = 0;                 // Reboot after N passes in log mode (0 = unlimited)
 uintptr_t       tty_address        = 0x3F8;             // Legacy IO or MMIO Address accepted
 int             tty_baud_rate      = 115200;
 int             tty_update_period  = 2;                 // Update TTY every 2 seconds (default)
@@ -302,6 +303,8 @@ static void parse_option(const char *option, const char *params)
     } else if (strncmp(option, "log", 4) == 0) {
         parse_serial_params(params);
         enable_tty_log = enable_tty;
+    } else if (strncmp(option, "maxpasses", 10) == 0) {
+        log_max_passes = parse_decimal(params, &params);
     } else if (strncmp(option, "newline", 7) == 0) {
         tty_new_line = true;
     } else if (strncmp(option, "cpuseqmode", 11) == 0) {

--- a/app/config.h
+++ b/app/config.h
@@ -62,6 +62,7 @@ extern bool         enable_temp_ram;
 extern bool         enable_sm;
 extern bool         enable_tty;
 extern bool         enable_tty_log;
+extern int          log_max_passes;
 extern bool         enable_bench;
 extern bool         enable_mch_read;
 extern bool         enable_ecc_polling;

--- a/app/config.h
+++ b/app/config.h
@@ -61,6 +61,7 @@ extern bool         enable_temp_ram;
 
 extern bool         enable_sm;
 extern bool         enable_tty;
+extern bool         enable_tty_log;
 extern bool         enable_bench;
 extern bool         enable_mch_read;
 extern bool         enable_ecc_polling;

--- a/app/error.c
+++ b/app/error.c
@@ -26,6 +26,7 @@
 #include "serial.h"
 #include "memctrl.h"
 #include "error.h"
+#include "reports.h"
 
 //------------------------------------------------------------------------------
 // Constants
@@ -203,6 +204,8 @@ static void common_err(error_type_t type, uintptr_t addr, testword_t good, testw
                 test_list[test_num].errors++;
             }
         }
+        static const char * const log_type[] = { "addr", "data", "parity", "uecc", "ecc" };
+        serial_log_error(log_type[type], page, offset, good, bad);
     }
 
     switch (error_mode) {
@@ -412,4 +415,6 @@ void error_update(void)
             tty_error_redraw();
         }
     }
+
+    serial_log_tick();
 }

--- a/app/main.c
+++ b/app/main.c
@@ -47,6 +47,7 @@
 #include "config.h"
 #include "display.h"
 #include "error.h"
+#include "reports.h"
 #include "test.h"
 
 #include "tests.h"
@@ -318,6 +319,8 @@ static void global_init(void)
     memctrl_init();
 
     tty_init();
+
+    serial_log_start();
 
     smp_init(smp_enabled);
 
@@ -730,6 +733,7 @@ void main(void)
                     display_start_run();
                     badram_init();
                     error_init();
+                    serial_log_run_start();
                 }
             }
             if (start_pass) {
@@ -739,6 +743,7 @@ void main(void)
                     ticks_per_pass[pass_num] = 0;
                 } else {
                     display_start_pass();
+                    serial_log_event(SLOG_PASS_START);
                 }
             }
             if (start_test) {
@@ -749,6 +754,7 @@ void main(void)
                     ticks_per_test[pass_num][test_num] = 0;
                 } else if (test_list[test_num].enabled) {
                     display_start_test();
+                    serial_log_event(SLOG_TEST_START);
                 }
                 bail = false;
             }
@@ -816,6 +822,8 @@ void main(void)
 
         if (dummy_run) {
             ticks_per_pass[pass_num] += ticks_per_test[pass_num][test_num];
+        } else if (test_list[test_num].enabled) {
+            serial_log_event(SLOG_TEST_END);
         }
 
         start_test = true;
@@ -824,6 +832,9 @@ void main(void)
             continue;
         }
 
+        if (!dummy_run) {
+            serial_log_event(SLOG_PASS_END);
+        }
         pass_num++;
         if (dummy_run && pass_num == NUM_PASS_TYPES) {
             start_run = true;

--- a/app/reports.c
+++ b/app/reports.c
@@ -7,11 +7,15 @@
 #include "heap.h"
 #include "memctrl.h"
 #include "pmem.h"
+#include "serial.h"
 #include "smbios.h"
+#include "smp.h"
 #include "spd.h"
 #include "usbhcd.h"
 #include "usbmsd.h"
 #include "fat32.h"
+
+#include "config.h"
 
 #include "display.h"
 #include "error.h"
@@ -38,6 +42,18 @@
 
 #define MILLISEC    1000
 
+#define SERIAL_LOG_INTERVAL     10  // Seconds between serial log progress lines.
+
+#if defined(__x86_64__)
+#define SLOG_ARCH   "x64"
+#elif defined(__i386__)
+#define SLOG_ARCH   "x32"
+#elif defined(__loongarch_lp64)
+#define SLOG_ARCH   "la64"
+#elif defined(__aarch64__)
+#define SLOG_ARCH   "arm64"
+#endif
+
 //------------------------------------------------------------------------------
 // Private Functions
 //------------------------------------------------------------------------------
@@ -55,6 +71,47 @@ static uint8_t rtc_read(uint8_t reg)
 static uint8_t bcd_to_bin(uint8_t bcd)
 {
     return (bcd >> 4) * 10 + (bcd & 0x0F);
+}
+
+static void rtc_get_datetime(int *year, int *mon, int *day, int *hour, int *min, int *sec)
+{
+    // Wait for any update in progress to complete (UIP bit, status register A).
+    for (int i = 0; i < 20000 && (rtc_read(0x0A) & 0x80); i++) {}
+
+    uint8_t rtc_stb  = rtc_read(0x0B);
+    uint8_t rtc_sec  = rtc_read(0x00);
+    uint8_t rtc_min  = rtc_read(0x02);
+    uint8_t rtc_hour = rtc_read(0x04);
+    uint8_t rtc_day  = rtc_read(0x07);
+    uint8_t rtc_mon  = rtc_read(0x08);
+    uint8_t rtc_year = rtc_read(0x09);
+    uint8_t rtc_cent = rtc_read(0x32);
+
+    bool rtc_pm = rtc_hour & 0x80;
+    rtc_hour &= 0x7F;
+
+    // Registers are BCD unless the RTC is in binary mode (status register B, DM bit).
+    if (!(rtc_stb & 0x04)) {
+        rtc_sec  = bcd_to_bin(rtc_sec);
+        rtc_min  = bcd_to_bin(rtc_min);
+        rtc_hour = bcd_to_bin(rtc_hour);
+        rtc_day  = bcd_to_bin(rtc_day);
+        rtc_mon  = bcd_to_bin(rtc_mon);
+        rtc_year = bcd_to_bin(rtc_year);
+        rtc_cent = bcd_to_bin(rtc_cent);
+    }
+
+    // Convert 12-hour mode (hour bit 7 = PM) to 24-hour.
+    if (!(rtc_stb & 0x02)) {
+        rtc_hour = rtc_hour % 12 + (rtc_pm ? 12 : 0);
+    }
+
+    *year = (rtc_cent ? rtc_cent * 100 : 2000) + rtc_year;
+    *mon  = rtc_mon;
+    *day  = rtc_day;
+    *hour = rtc_hour;
+    *min  = rtc_min;
+    *sec  = rtc_sec;
 }
 #endif
 
@@ -117,11 +174,8 @@ static char *buf_append_int(char *pos, int value, int min_width)
     return buf_append_uint(pos, value, 10, min_width);
 }
 
-static char *buf_printf(char *pos, const char *fmt, ...)
+static char *buf_vprintf(char *pos, const char *fmt, va_list args)
 {
-    va_list args;
-    va_start(args, fmt);
-
     while (*fmt) {
         if (*fmt != '%') {
             pos = buf_append_char(pos, *fmt++);
@@ -161,8 +215,28 @@ static char *buf_printf(char *pos, const char *fmt, ...)
         if (*fmt) fmt++;
     }
 
+    return pos;
+}
+
+static char *buf_printf(char *pos, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    pos = buf_vprintf(pos, fmt, args);
     va_end(args);
     return pos;
+}
+
+// Extract the description text from between the brackets, trailing spaces trimmed.
+static int test_desc_text(int n, const char **text)
+{
+    const char *start = test_list[n].description;
+    if (*start == '[') start++;
+    int len = 0;
+    while (start[len] && start[len] != ']') len++;
+    while (len > 0 && start[len - 1] == ' ') len--;
+    *text = start;
+    return len;
 }
 
 static int format_results(char *buf, int bufsize)
@@ -175,40 +249,10 @@ static int format_results(char *buf, int bufsize)
 
     // Date & time from RTC (x86 ISA CMOS only).
 #if defined(__i386__) || defined(__x86_64__)
-    // Wait for any update in progress to complete (UIP bit, status register A).
-    for (int i = 0; i < 20000 && (rtc_read(0x0A) & 0x80); i++) {}
-
-    uint8_t rtc_stb  = rtc_read(0x0B);
-    uint8_t rtc_sec  = rtc_read(0x00);
-    uint8_t rtc_min  = rtc_read(0x02);
-    uint8_t rtc_hour = rtc_read(0x04);
-    uint8_t rtc_day  = rtc_read(0x07);
-    uint8_t rtc_mon  = rtc_read(0x08);
-    uint8_t rtc_year = rtc_read(0x09);
-    uint8_t rtc_cent = rtc_read(0x32);
-
-    bool rtc_pm = rtc_hour & 0x80;
-    rtc_hour &= 0x7F;
-
-    // Registers are BCD unless the RTC is in binary mode (status register B, DM bit).
-    if (!(rtc_stb & 0x04)) {
-        rtc_sec  = bcd_to_bin(rtc_sec);
-        rtc_min  = bcd_to_bin(rtc_min);
-        rtc_hour = bcd_to_bin(rtc_hour);
-        rtc_day  = bcd_to_bin(rtc_day);
-        rtc_mon  = bcd_to_bin(rtc_mon);
-        rtc_year = bcd_to_bin(rtc_year);
-        rtc_cent = bcd_to_bin(rtc_cent);
-    }
-
-    // Convert 12-hour mode (hour bit 7 = PM) to 24-hour.
-    if (!(rtc_stb & 0x02)) {
-        rtc_hour = rtc_hour % 12 + (rtc_pm ? 12 : 0);
-    }
-
-    int full_year = (rtc_cent ? rtc_cent * 100 : 2000) + rtc_year;
+    int year, mon, day, hour, min, sec;
+    rtc_get_datetime(&year, &mon, &day, &hour, &min, &sec);
     pos = buf_printf(pos, "Date: %04i-%02i-%02i %02i:%02i:%02i\r\n",
-                     full_year, rtc_mon, rtc_day, rtc_hour, rtc_min, rtc_sec);
+                     year, mon, day, hour, min, sec);
     pos = buf_printf(pos, "\r\n");
 #endif
 
@@ -304,14 +348,8 @@ static int format_results(char *buf, int bufsize)
         if (!test_list[i].enabled) {
             continue;
         }
-        // Extract description text from between brackets.
-        const char *desc = test_list[i].description;
-        const char *start = desc;
-        if (*start == '[') start++;
-        int len = 0;
-        while (start[len] && start[len] != ']') len++;
-        // Trim trailing spaces.
-        while (len > 0 && start[len - 1] == ' ') len--;
+        const char *start;
+        int len = test_desc_text(i, &start);
 
         pos = buf_printf(pos, "  Test %02i: [", i);
         for (int j = 0; j < len; j++) {
@@ -356,6 +394,62 @@ static int format_results(char *buf, int bufsize)
     *pos = '\0';
 
     return (int)(pos - buf);
+}
+
+//------------------------------------------------------------------------------
+// Serial Log
+//------------------------------------------------------------------------------
+
+static char     slog_buf[256];
+
+static uint64_t log_start_time = 0;
+static uint64_t next_log_time  = 0;
+static bool     log_running    = false;
+static bool     log_error_seen = false;
+
+static int      log_test_ticks = 0;
+static int      log_pass_ticks = 0;
+
+// Start a log line with the "MTLOG ts=<sec>.<decisec> ev=<event>" prefix.
+static char *slog_begin(const char *event)
+{
+    uintptr_t ds = 0;
+
+    buf_end = slog_buf + sizeof(slog_buf) - 3;  // Reserve space for CR, LF, NUL.
+
+    if (clks_per_msec > 0) {
+        ds = (uintptr_t)((get_tsc() - log_start_time) / (100 * (uint64_t)clks_per_msec));
+    }
+    return buf_printf(slog_buf, "MTLOG ts=%u.%u ev=%s", ds / 10, ds % 10, event);
+}
+
+static void slog_end(char *pos)
+{
+    if (pos > buf_end) pos = buf_end;
+    *pos++ = '\r';
+    *pos++ = '\n';
+    *pos   = '\0';
+    tty_send_string(slog_buf);
+}
+
+// Emit a complete log line in one call.
+static void slog(const char *event, const char *fmt, ...)
+{
+    char *pos = slog_begin(event);
+
+    va_list args;
+    va_start(args, fmt);
+    pos = buf_vprintf(pos, fmt, args);
+    va_end(args);
+
+    slog_end(pos);
+}
+
+static int slog_pct(int ticks, int total)
+{
+    if (total <= 0) return 0;
+    int pct = 100 * ticks / total;
+    return pct > 100 ? 100 : pct;
 }
 
 //------------------------------------------------------------------------------
@@ -454,4 +548,142 @@ cleanup:
     // by the bulk transfer event handling.
     usb_rearm_keyboards();
     heap_rewind(HEAP_TYPE_LM_1, heap_lm_mark);
+}
+
+void serial_log_start(void)
+{
+    if (!enable_tty_log) return;
+
+    if (clks_per_msec > 0) {
+        log_start_time = get_tsc();
+    }
+
+    slog("start", " version=" MT_VERSION "." GIT_HASH " arch=" SLOG_ARCH);
+}
+
+void serial_log_run_start(void)
+{
+    if (!enable_tty_log) return;
+
+#if defined(__i386__) || defined(__x86_64__)
+    int year, mon, day, hour, min, sec;
+    rtc_get_datetime(&year, &mon, &day, &hour, &min, &sec);
+    slog("info", " rtc=\"%04i-%02i-%02i %02i:%02i:%02i\"", year, mon, day, hour, min, sec);
+#endif
+
+    if (cpu_model) {
+        slog("info", " cpu=\"%s\"", cpu_model);
+    }
+
+    const char *board_mfg, *board_prod;
+    get_smbios_board_info(&board_mfg, &board_prod);
+    if (board_mfg && board_prod) {
+        slog("info", " board=\"%s %s\"", board_mfg, board_prod);
+    }
+
+    const char *system_serial, *baseboard_serial;
+    get_smbios_serial_info(&system_serial, &baseboard_serial);
+    if (system_serial) {
+        slog("info", " sys_serial=\"%s\"", system_serial);
+    }
+    if (baseboard_serial) {
+        slog("info", " board_serial=\"%s\"", baseboard_serial);
+    }
+
+    slog("info", " mem_mb=%u", (uintptr_t)(num_pm_pages / 256));
+
+    if (imc.freq) {
+        slog("info", " imc=%s-%u cas=%u%s-%u-%u-%u",
+             imc.type, (uintptr_t)imc.freq, (uintptr_t)imc.tCL, imc.tCL_dec ? ".5" : "",
+             (uintptr_t)imc.tRCD, (uintptr_t)imc.tRP, (uintptr_t)imc.tRAS);
+    } else if (ram.freq > 0 && ram.tCL > 0) {
+        slog("info", " ram=%s-%u cas=%u%s-%u-%u-%u",
+             ram.type, (uintptr_t)ram.freq, (uintptr_t)ram.tCL, ram.tCL_dec ? ".5" : "",
+             (uintptr_t)ram.tRCD, (uintptr_t)ram.tRP, (uintptr_t)ram.tRAS);
+    }
+
+    for (int i = 0; i < MAX_SPD_SLOT; i++) {
+        const spd_info *spdi = &spd_slot_cache[i];
+        if (!spdi->isValid) continue;
+
+        char *pos = slog_begin("spd");
+        pos = buf_printf(pos, " slot=%i size_mb=%u type=%s freq=%u ecc=%i",
+                         spdi->slot_num, (uintptr_t)spdi->module_size,
+                         spdi->type, (uintptr_t)spdi->freq, spdi->hasECC ? 1 : 0);
+
+        const char *mfg = get_jep106_name(spdi->jedec_code);
+        if (mfg) {
+            pos = buf_printf(pos, " mfg=\"%s\"", mfg);
+        } else if (spdi->jedec_code != 0) {
+            pos = buf_printf(pos, " mfg_id=0x%x", (uintptr_t)spdi->jedec_code);
+        }
+
+        if (spdi->sku[0]) {
+            pos = buf_printf(pos, " sku=\"%s\"", spdi->sku);
+        }
+        slog_end(pos);
+    }
+
+    log_running = true;
+}
+
+void serial_log_event(slog_event_t event)
+{
+    if (!log_running) return;
+
+    switch (event) {
+      case SLOG_PASS_START:
+        log_pass_ticks = 0;
+        slog("pass_start", " pass=%i", pass_num);
+        break;
+      case SLOG_PASS_END:
+        slog("pass_end", " pass=%i errors=%u status=%s",
+             pass_num, (uintptr_t)error_count, error_count == 0 ? "pass" : "fail");
+        break;
+      case SLOG_TEST_START: {
+        log_error_seen = false;
+        log_test_ticks = 0;
+        const char *text;
+        int len = test_desc_text(test_num, &text);
+        char name[40];
+        memcpy(name, text, len);
+        name[len] = '\0';
+        slog("test_start", " test=%i name=\"%s\"", test_num, name);
+        break;
+      }
+      case SLOG_TEST_END:
+        slog("test_end", " test=%i errors=%i", test_num, test_list[test_num].errors);
+        break;
+    }
+}
+
+void serial_log_tick(void)
+{
+    if (!log_running || clks_per_msec == 0) return;
+
+    log_test_ticks++;
+    log_pass_ticks++;
+
+    uint64_t now = get_tsc();
+    if (now < next_log_time) return;
+    next_log_time = now + SERIAL_LOG_INTERVAL * 1000 * (uint64_t)clks_per_msec;
+
+    // Same progress calculation as do_tick(), from our own tick counters.
+    pass_type_t pass_type = (pass_num == 0) ? FAST_PASS : FULL_PASS;
+
+    slog("prog", " pass=%i pass_pct=%i test=%i test_pct=%i errors=%u",
+         pass_num, slog_pct(log_pass_ticks, ticks_per_pass[pass_type]),
+         test_num, slog_pct(log_test_ticks, ticks_per_test[pass_type][test_num]),
+         (uintptr_t)error_count);
+}
+
+void serial_log_error(const char *type, testword_t page, testword_t offset, testword_t expect, testword_t actual)
+{
+    if (!log_running || log_error_seen) return;
+
+    log_error_seen = true;
+
+    slog("error", " type=%s test=%i cpu=%i addr=0x%x%03x expect=0x%x actual=0x%x",
+         type, test_num, smp_my_cpu_num(),
+         (uintptr_t)page, (uintptr_t)offset, (uintptr_t)expect, (uintptr_t)actual);
 }

--- a/app/reports.c
+++ b/app/reports.c
@@ -678,7 +678,7 @@ void serial_log_tick(void)
     // Same progress calculation as do_tick(), from our own tick counters.
     pass_type_t pass_type = (pass_num == 0) ? FAST_PASS : FULL_PASS;
 
-    slog("prog", " pass=%i pass_pct=%i test=%i test_pct=%i errors=%u",
+    slog("tick", " pass=%i pass_pct=%i test=%i test_pct=%i errors=%u",
          pass_num, slog_pct(log_pass_ticks, ticks_per_pass[pass_type]),
          test_num, slog_pct(log_test_ticks, ticks_per_test[pass_type][test_num]),
          (uintptr_t)error_count);

--- a/app/reports.c
+++ b/app/reports.c
@@ -5,6 +5,7 @@
 #include "tsc.h"
 #include "io.h"
 #include "heap.h"
+#include "hwctrl.h"
 #include "memctrl.h"
 #include "pmem.h"
 #include "serial.h"
@@ -639,6 +640,12 @@ void serial_log_event(slog_event_t event)
       case SLOG_PASS_END:
         slog("pass_end", " pass=%i errors=%u status=%s",
              pass_num, (uintptr_t)error_count, error_count == 0 ? "pass" : "fail");
+        // Hooked before main() increments pass_num, so completed passes = pass_num + 1.
+        if (log_max_passes > 0 && pass_num + 1 >= log_max_passes) {
+            slog("done", " passes=%i status=%s", pass_num + 1, error_count == 0 ? "pass" : "fail");
+            usleep(100 * MILLISEC);  // Let the UART drain the last line.
+            reboot();
+        }
         break;
       case SLOG_TEST_START: {
         log_error_seen = false;

--- a/app/reports.h
+++ b/app/reports.h
@@ -4,11 +4,14 @@
 /**
  * \file
  *
- * Provides the ability to save test results to a FAT32-formatted USB drive.
+ * Provides the ability to save test results to a FAT32-formatted USB drive
+ * and to emit a machine-parseable test log over the serial port.
  *
  *//*
  * Copyright (C) 2026 Sam Demeulemeester.
  */
+
+#include "test.h"
 
 /**
  * Searches for a USB mass storage device, mounts its FAT32 filesystem,
@@ -16,5 +19,35 @@
  * Displays status messages in the popup area during the operation.
  */
 void save_results_to_usb(void);
+
+/**
+ * Emits the serial log start banner. All serial log functions are no-ops
+ * unless the "log" boot option was given.
+ */
+void serial_log_start(void);
+
+/**
+ * Emits the system information block (DMI, IMC, SPD) and enables the
+ * periodic log output. Call when the first real test run starts.
+ */
+void serial_log_run_start(void);
+
+typedef enum { SLOG_PASS_START, SLOG_PASS_END, SLOG_TEST_START, SLOG_TEST_END } slog_event_t;
+
+/**
+ * Emits a pass/test lifecycle event.
+ */
+void serial_log_event(slog_event_t event);
+
+/**
+ * Emits a progress line at most every SERIAL_LOG_INTERVAL seconds.
+ * Call once per test tick; also counts ticks for the progress percentages.
+ */
+void serial_log_tick(void);
+
+/**
+ * Emits an error detail line (at most one per test).
+ */
+void serial_log_error(const char *type, testword_t page, testword_t offset, testword_t expect, testword_t actual);
 
 #endif // REPORTS_H

--- a/system/serial.c
+++ b/system/serial.c
@@ -110,7 +110,7 @@ static void tty_goto(int y, int x)
 
 void tty_init(void)
 {
-    if (!enable_tty) {
+    if (!enable_tty && !enable_tty_log) {
         return;
     }
 
@@ -149,8 +149,10 @@ void tty_init(void)
     if (console_serial.is_pl011) {
         // The PL011 has already been configured by the firmware; just use
         // it as-is.
-        tty_clear_screen();
-        tty_disable_cursor();
+        if (enable_tty) {
+            tty_clear_screen();
+            tty_disable_cursor();
+        }
         return;
     }
 
@@ -181,8 +183,16 @@ void tty_init(void)
         serial_write_reg(&console_serial, UART_FCR, (0xFF) & (UART_FCR_ENA | UART_FCR_THR));
     }
 
-    tty_clear_screen();
-    tty_disable_cursor();
+    // Log mode wants a raw byte stream, so don't emit VT100 sequences.
+    if (enable_tty) {
+        tty_clear_screen();
+        tty_disable_cursor();
+    }
+}
+
+void tty_send_string(const char *p)
+{
+    serial_echo_print(p);
 }
 
 void tty_send_region(int start_row, int start_col, int end_row, int end_col)

--- a/system/serial.h
+++ b/system/serial.h
@@ -189,6 +189,8 @@ void tty_init(void);
 
 void tty_print(int y, int x, const char *p);
 
+void tty_send_string(const char *p);
+
 void tty_send_region(int start_row, int start_col, int end_row, int end_col);
 
 char tty_get_char(int max_wait_frames);


### PR DESCRIPTION
The new "log" option (same parameters as "console=", mutually exclusive with it) emits one line per event.
`MTLOG ts=<sec> ev=<event> key=value` 
Content is: start banner, system info (DMI/IMC/SPD, mirroring the USB report), pass and test lifecycle, 10-second progress beacons, and errors (one detailed line per test, running counts elsewhere). 

The companion "maxpasses=n" option, for unattended test rigs, stops after x completed passes: 
a final "ev=done" line is emitted, then the machine reboots. Ignored outside log mode.

Based on original ideas from PR #638 and PR #639.

Co-authored-by: classabbyamp <classabbyamp@users.noreply.github.com>
Suggested-by: gnubie2 <gnubie2@users.noreply.github.com>