### PR TITLE
Add SPD Checksum/CRC check at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ recognised:
     * disables the big PASS/FAIL pop-up status display
   * nosm
     * disables SMBUS/SPD parsing, DMI decoding and memory benchmark
+  * nospdcrc
+    * disables SPD checksum/CRC verification
   * nomch
     * disables memory controller configuration polling
   * nopause

--- a/app/config.c
+++ b/app/config.c
@@ -99,6 +99,7 @@ bool            enable_temp_cpu    = true;
 bool            enable_temp_ram    = true;              // DDR5+ temperature polling
 
 bool            enable_sm          = true;
+bool            enable_spd_crc     = true;
 bool            enable_bench       = true;
 bool            enable_mch_read    = true;
 bool            enable_numa        = false;
@@ -348,6 +349,8 @@ static void parse_option(const char *option, const char *params)
         enable_sm = false;
     } else if (strncmp(option, "nosmp", 6) == 0) {
         smp_enabled = false;
+    } else if (strncmp(option, "nospdcrc", 9) == 0) {
+        enable_spd_crc = false;
     } else if (strncmp(option, "numa", 5) == 0) {
         enable_numa = true;
     } else if (strncmp(option, "nonuma", 7) == 0) {

--- a/app/config.h
+++ b/app/config.h
@@ -60,6 +60,7 @@ extern bool         enable_temp_cpu;
 extern bool         enable_temp_ram;
 
 extern bool         enable_sm;
+extern bool         enable_spd_crc;
 extern bool         enable_tty;
 extern bool         enable_bench;
 extern bool         enable_mch_read;

--- a/app/reports.c
+++ b/app/reports.c
@@ -276,6 +276,10 @@ static int format_results(char *buf, int bufsize)
                          spdi->slot_num, (uintptr_t)spdi->module_size,
                          spdi->type, (uintptr_t)spdi->freq);
 
+        if (spdi->hasBadCRC) {
+            pos = buf_printf(pos, " [BAD CRC]");
+        }
+
         if (spdi->hasECC) {
             pos = buf_printf(pos, " ECC");
         }

--- a/system/spd.c
+++ b/system/spd.c
@@ -5,6 +5,9 @@
 #include "stdint.h"
 #include "string.h"
 
+#include "config.h"
+#include "display.h"
+
 #include "i2c_x86.h"
 #include "spd.h"
 #include "print.h"
@@ -76,6 +79,13 @@ void print_spdi(spd_info spdi, uint8_t row)
                     spdi.module_size * 1024,
                     spdi.type,
                     spdi.freq);
+
+    // Flag modules with an invalid SPD checksum/CRC
+    if (spdi.hasBadCRC) {
+        set_foreground_colour(BOLD + RED);
+        curcol = prints(row, ++curcol, "BAD CRC!");
+        set_foreground_colour(palette.foreground);
+    }
 
     // Print ECC status
     if (spdi.hasECC) {
@@ -990,6 +1000,51 @@ static void parse_spd_sdram(spd_info *spdi, uint8_t slot_idx)
     spdi->isValid = true;
 }
 
+// JEDEC SPD CRC16 (XMODEM: poly 0x1021, init 0) over bytes [0, count)
+static uint16_t spd_crc16(uint8_t slot_idx, uint16_t count)
+{
+    uint16_t crc = 0;
+
+    for (uint16_t adr = 0; adr < count; adr++) {
+        crc ^= (uint16_t)get_spd(slot_idx, adr) << 8;
+        for (int i = 0; i < 8; i++) {
+            crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+        }
+    }
+    return crc;
+}
+
+static bool spd_check_crc16(uint8_t slot_idx, uint16_t count, uint16_t crc_adr)
+{
+    uint16_t crc = get_spd(slot_idx, crc_adr) | (uint16_t)get_spd(slot_idx, crc_adr + 1) << 8;
+
+    return spd_crc16(slot_idx, count) == crc;
+}
+
+static bool spd_checksum_ok(uint8_t slot_idx, uint8_t spd_type)
+{
+    switch (spd_type)
+    {
+        case 0x12: // DDR5: CRC16 over bytes 0-509, stored at 510/511
+            return spd_check_crc16(slot_idx, 510, 510);
+        case 0x0C: // DDR4: base config bytes 0-125 only (block 1 CRC often unprogrammed)
+            return spd_check_crc16(slot_idx, 126, 126);
+        case 0x0B: // DDR3: byte0[7] set excludes mfg bytes 117-125 from coverage
+            return spd_check_crc16(slot_idx, (get_spd(slot_idx, 0) & 0x80) ? 117 : 126, 126);
+        case 0x08: // DDR2 / DDR / SDRAM: byte 63 = LSB of sum of bytes 0-62
+        case 0x07:
+        case 0x04: {
+            uint8_t sum = 0;
+            for (uint8_t adr = 0; adr < 63; adr++) {
+                sum += get_spd(slot_idx, adr);
+            }
+            return sum == get_spd(slot_idx, 63);
+        }
+        default:   // RDRAM & others: no checksum defined
+            return true;
+    }
+}
+
 void parse_spd(spd_info *spdi, uint8_t slot_idx)
 {
     memset(spdi, 0, sizeof(*spdi));     // Also sets isValid to False
@@ -998,7 +1053,9 @@ void parse_spd(spd_info *spdi, uint8_t slot_idx)
     if (get_spd(slot_idx, 0) == 0xFF)
         return;
 
-    switch(get_spd(slot_idx, 2))
+    uint8_t spd_type = get_spd(slot_idx, 2);
+
+    switch(spd_type)
     {
         case 0x12: // DDR5
             parse_spd_ddr5(spdi, slot_idx);
@@ -1023,5 +1080,11 @@ void parse_spd(spd_info *spdi, uint8_t slot_idx)
                 parse_spd_rdram(spdi, slot_idx);
             }
             break;
+    }
+
+    // Verify twice on mismatch so a transient SMBUS misread can't flag a good module
+    if (enable_spd_crc && spdi->isValid
+        && !spd_checksum_ok(slot_idx, spd_type) && !spd_checksum_ok(slot_idx, spd_type)) {
+        spdi->hasBadCRC = true;
     }
 }

--- a/system/spd.h
+++ b/system/spd.h
@@ -38,6 +38,7 @@ typedef struct spd_infos {
     uint16_t    freq;
     bool        hasECC;
     bool        hasTempSensor;
+    bool        hasBadCRC;
     uint8_t     fab_year;
     uint8_t     fab_week;
     uint16_t    tCL;


### PR DESCRIPTION
Verify the JEDEC SPD checksum of each module after parsing, and flag modules with corrupted SPD content, which can hang POST on some boards while every existing tool silently ignores the invalid checksum 

Closes #532